### PR TITLE
[feat] Refactor VectorDB class hierarchy for flexibility

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -11,6 +11,7 @@ from embedchain.loaders.web_page import WebPageLoader
 from embedchain.chunkers.youtube_video import YoutubeVideoChunker
 from embedchain.chunkers.pdf_file import PdfFileChunker
 from embedchain.chunkers.web_page import WebPageChunker
+from embedchain.vectordb.chroma_db import ChromaDB
 
 load_dotenv()
 
@@ -21,13 +22,15 @@ DB_DIR = os.path.join(ABS_PATH, "db")
 
 
 class EmbedChain:
-    def __init__(self, db):
+    def __init__(self, db=None):
         """
          Initializes the EmbedChain instance, sets up a vector DB client and
         creates a collection.
 
         :param db: The instance of the VectorDB subclass.
         """
+        if db is None:
+            db = ChromaDB()
         self.db_client = db.client
         self.collection = db.collection
         self.user_asks = []

--- a/embedchain/vectordb/base_vector_db.py
+++ b/embedchain/vectordb/base_vector_db.py
@@ -1,0 +1,10 @@
+class BaseVectorDB:
+    def __init__(self):
+        self.client = self._get_or_create_db()
+        self.collection = self._get_or_create_collection()
+
+    def _get_or_create_db(self):
+        raise NotImplementedError
+
+    def _get_or_create_collection(self):
+        raise NotImplementedError

--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -1,0 +1,26 @@
+import os
+import chromadb
+from base_vector_db import BaseVectorDB
+from chromadb.utils import embedding_functions
+
+openai_ef = embedding_functions.OpenAIEmbeddingFunction(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    model_name="text-embedding-ada-002"
+)
+
+class ChromaDB(BaseVectorDB):
+    def __init__(self, db_dir):
+        self.client_settings = chromadb.config.Settings(
+            chroma_db_impl="duckdb+parquet",
+            persist_directory=db_dir,
+            anonymized_telemetry=False
+        )
+        super().__init__()
+
+    def _get_or_create_db(self):
+        return chromadb.Client(self.client_settings)
+
+    def _get_or_create_collection(self):
+        return self.client.get_or_create_collection(
+            'embedchain_store', embedding_function=openai_ef,
+        )

--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -1,7 +1,9 @@
-import os
 import chromadb
-from base_vector_db import BaseVectorDB
+import os
+
 from chromadb.utils import embedding_functions
+
+from embedchain.vectordb.base_vector_db import BaseVectorDB
 
 openai_ef = embedding_functions.OpenAIEmbeddingFunction(
     api_key=os.getenv("OPENAI_API_KEY"),
@@ -9,7 +11,9 @@ openai_ef = embedding_functions.OpenAIEmbeddingFunction(
 )
 
 class ChromaDB(BaseVectorDB):
-    def __init__(self, db_dir):
+    def __init__(self, db_dir=None):
+        if db_dir is None:
+            db_dir = "db"
         self.client_settings = chromadb.config.Settings(
             chroma_db_impl="duckdb+parquet",
             persist_directory=db_dir,


### PR DESCRIPTION
Introduced a new base class, BaseVectorDB, with abstract methods _get_or_create_db and _get_or_create_collection. This allows for an arbitrary VectorDB implementation to be plugged into the EmbedChain.

- Refactored EmbedChain to take an instance of BaseVectorDB during initialization, promoting greater flexibility and adherence to the Dependency Inversion Principle.

- Implemented ChromaDB as subclasses of BaseVectorDB. These can now be used interchangeably when creating an EmbedChain instance.

This commit makes the EmbedChain more flexible and extensible. Different types of VectorDB can now be used interchangeably with EmbedChain without the need for modifying EmbedChain's code.

To Use:
> chroma_db = ChromaDB('path/to/your/db')
naval_chat_bot = App(chroma_db)