### PR TITLE
fix: add database to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 
 .ideas.md
 .todos.md
+
+# Database
+db


### PR DESCRIPTION
all the files that are generated for the db when you run the code currently are not ignored. I guess it depends on where you run it, but I think they should be ignored for the dev experience. 