### PR TITLE
refactor: methods used to query

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -127,8 +127,39 @@ class EmbedChain:
             top_p=1,
         )
         return response["choices"][0]["message"]["content"]
+    
+    def retrieve_from_database(self, input_query):
+        """
+        Queries the vector database based on the given input query.
+        Gets relevant doc based on the query
 
-    def get_answer_from_llm(self, query, context):
+        :param input_query: The query to use.
+        :return: The content of the document that matched your query.
+        """
+        result = self.collection.query(
+            query_texts=[input_query,],
+            n_results=1,
+        )
+        result_formatted = self._format_result(result)
+        content = result_formatted[0][0].page_content
+        return content
+    
+    def generate_prompt(self, input_query, context):
+        """
+        Generates a prompt based on the given query and context, ready to be passed to an LLM
+
+        :param input_query: The query to use.
+        :param context: Similar documents to the query used as context.
+        :return: The Prompt
+        """
+        prompt = f"""Use the following pieces of context to answer the query at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
+        {context}
+        Query: {input_query}
+        Helpful Answer:
+        """
+        return prompt
+
+    def get_answer_from_llm(self, prompt):
         """
         Gets an answer based on the given query and context by passing it
         to an LLM.
@@ -136,11 +167,6 @@ class EmbedChain:
         :param query: The query to use.
         :param context: Similar documents to the query used as context.
         :return: The answer.
-        """
-        prompt = f"""Use the following pieces of context to answer the query at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
-        {context}
-        Query: {query}
-        Helpful Answer:
         """
         answer = self.get_openai_answer(prompt)
         return answer
@@ -154,12 +180,9 @@ class EmbedChain:
         :param input_query: The query to use.
         :return: The answer to the query.
         """
-        result = self.collection.query(
-            query_texts=[input_query,],
-            n_results=1,
-        )
-        result_formatted = self._format_result(result)
-        answer = self.get_answer_from_llm(input_query, result_formatted[0][0].page_content)
+        context = self.retrieve_from_database(input_query)
+        prompt = self.generate_prompt(input_query, context)
+        answer = self.get_answer_from_llm(prompt)
         return answer
 
 

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -150,7 +150,7 @@ class EmbedChain:
 
         :param input_query: The query to use.
         :param context: Similar documents to the query used as context.
-        :return: The Prompt
+        :return: The prompt
         """
         prompt = f"""Use the following pieces of context to answer the query at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer.
         {context}


### PR DESCRIPTION
I refactored the methods. It still works the exact same, here's the idea, how and why.

# The idea

The query method is the end user exposed method. It should be as abstract as possible and only combine the use of other methods. No slicing or formatting should be done here.

# How I did it

I created a `retrieve_from_database` for the retrieval process. It includes all database related operations and the filtering.

I moved the prompt generation out of the `generate_answer_from_llm` method, into it's own method.

I cleaned up  `generate_answer_from_llm` and `query`.

# Why?

**My original intention was to create a dry run method**, where you can test the prompts and your database, without actually sending them and without consuming tokens. After this PR it will be easy, simply by copying the `query` method and leaving out `generate_answer_from_llm`.

It also has some nice side effect. If we want to play around with the prompt and change the *retrieval prompt*, it's easier and clearer to find now.

Another positive is related to #38 - if we want to allow configuration for the retrieval process, it's also clearer where it should go. 

The only thing I dislike is that `generate_answer_from_llm` just contains one function now, `get_openai_answer`. So it's essentially just an alias. I would still keep it this way, because there will be (have been?) requests to use other LLMs, and this would be the place to add them. 