### PR TITLE
Fix: Solve IndexError when no relevant documents are found in the vector db.

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -26,7 +26,7 @@ DB_DIR = os.path.join(ABS_PATH, "db")
 class EmbedChain:
     def __init__(self, db=None):
         """
-         Initializes the EmbedChain instance, sets up a vector DB client and
+        Initializes the EmbedChain instance, sets up a vector DB client and
         creates a collection.
 
         :param db: The instance of the VectorDB subclass.

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -177,7 +177,10 @@ class EmbedChain:
             n_results=1,
         )
         result_formatted = self._format_result(result)
-        content = result_formatted[0][0].page_content
+        if result_formatted:
+            content = result_formatted[0][0].page_content
+        else:
+            content = ""
         return content
     
     def generate_prompt(self, input_query, context):


### PR DESCRIPTION
This PR will solve the following problem. When no similar document is found in the vector database or the vector database is empty,`result_formatted[0][0].page_content` will be triggered and `IndexError` will be triggered.

eg:

```python

result = self.collection.query(
            query_texts=[input_query,],
            n_results=1,
        )


# the result will be:
# {'ids': [[]], 'embeddings': None, 'documents': [[]], 'metadatas': [[]], 'distances': [[]]}

# and then, result_formatted = self._format_result(result) will return empty list.
# []
```