### PR TITLE
Typo with App instance name

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ os.environ["OPENAI_API_KEY"] = "sk-xxxx"
 
 from embedchain import App
 
-naval_ravikant_chat_bot_app = App()
+naval_chat_bot = App()
 
 # Embed Online Resources
 naval_chat_bot.add("youtube_video", "https://www.youtube.com/watch?v=3qHkcs3kG44")


### PR DESCRIPTION
There seems to be an error in the Readme file regarding the app instance name. It appears to be assigned as 'naval_ravikant_chat_bot_app' but the subsequent lines of code use 'naval_chat_bot'.