### PR TITLE
Allow setting OpenAI organization along with api_key

### DIFF
--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -7,6 +7,7 @@ from embedchain.vectordb.base_vector_db import BaseVectorDB
 
 openai_ef = embedding_functions.OpenAIEmbeddingFunction(
     api_key=os.getenv("OPENAI_API_KEY"),
+    organization_id=os.getenv("OPENAI_ORGANIZATION"),
     model_name="text-embedding-ada-002"
 )
 


### PR DESCRIPTION
In some cases we need to be able to set the OpenAI organization_id along with the OpenAI api_key. This is due to the way OpenAI has their access control organized with respect to users belonging to different Organizations.