### PR TITLE
fix: ValueError: Expected metadatas to be a list, got ({'url': 'local'},)

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -139,7 +139,7 @@ class EmbedChain:
 
         self.collection.add(
             documents=documents,
-            metadatas=metadatas,
+            metadatas=list(metadatas),
             ids=ids
         )
         print(f"Successfully saved {url}. Total chunks count: {self.collection.count()}")


### PR DESCRIPTION
Fixes #108.

Tested by using the built of the clone instead of pip in prod where I got the error.