### PR TITLE
[Enhancement]: for loading environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY='sk-xxxx'

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ pip install embedchain
 * We use OpenAI's embedding model to create embeddings for chunks and ChatGPT API as LLM to get answer given the relevant docs. Make sure that you have an OpenAI account and an API key. If you have dont have an API key, you can create one by visiting [this link](https://platform.openai.com/account/api-keys).
 
 * Once you have the API key, set it in an environment variable called `OPENAI_API_KEY`
+* Copy .env.example into .env Your .env file should look like this:
+* ```OPENAI_API_KEY= your_api_key_here```
 
 ```python
 import os

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -17,7 +17,7 @@ from embedchain.chunkers.qna_pair import QnaPairChunker
 from embedchain.chunkers.text import TextChunker
 from embedchain.vectordb.chroma_db import ChromaDB
 
-load_dotenv()
+load_dotenv(override=True)
 
 embeddings = OpenAIEmbeddings()
 


### PR DESCRIPTION
Hey, I created the following changes to easily allow the users to add their open_api_key.

update: enforce .env variables over system variables, I want to enforce the users to use the environment variables present in .env file. This will add more clarity which open_api_key you are using. The default load_dotenv behaviour, it will load system variables over defined variables in .env.

docs: added section for writing .env 

update: add an example of environment variables