### PR TITLE
[refactor] pass config object instead of pass db/ef params

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -45,10 +45,10 @@ class EmbedChain:
             - 'ef': Embeddings function to calculate the relatedness of text strings.
             - 'default_model': the default LLM model use during query.
         """
-        if config["db"] is None:
+        if config.get("db") is None:
             config["db"] = ChromaDB(ef=config.get("ef"))
-        db = config.get("db")
         self.default_model = config.get("default_model")
+        db = config.get("db")
         self.db_client = db.client
         self.collection = db.collection
         self.user_asks = []
@@ -276,9 +276,9 @@ class OpenSourceApp(EmbedChain):
 
     def __init__(self, config):
         print("Loading open source embedding model. This may take some time...")
-        if config["ef"] is None:
+        if config.get("ef") is None:
             config["ef"] = sentence_transformer_ef
-        if config["default_model"] is None:
+        if config.get("default_model") is None:
             config["default_model"] = "orca-mini-3b.ggmlv3.q4_0.bin"
         print("Successfully loaded open source embedding model.")
         super().__init__(config)

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -43,7 +43,7 @@ class EmbedChain:
         :param config: A dictionary containing the following keys:
             - 'db': The instance of the VectorDB subclass.
             - 'ef': Embeddings function to calculate the relatedness of text strings.
-            - 'default_model': the default LLM model to use.
+            - 'default_model': the default LLM model use during query.
         """
         if config["db"] is None:
             config["db"] = ChromaDB(ef=config.get("ef"))

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -35,7 +35,7 @@ DB_DIR = os.path.join(ABS_PATH, "db")
 
 
 class EmbedChain:
-    def __init__(self, config):
+    def __init__(self, config = {}):
         """
         Initializes the EmbedChain instance, sets up a vector DB client and
         creates a collection.
@@ -241,10 +241,10 @@ class App(EmbedChain):
     query(query): finds answer to the given query using vector database and LLM.
     """
 
-    def __int__(self, config):
-        if config["ef"] is None:
+    def __int__(self, config = {}):
+        if config.get("ef") is None:
             config["ef"] = openai_ef
-        if config["default_model"] is None:
+        if config.get("default_model") is None:
             config["default_model"] = "gpt-3.5-turbo-0613"
         super().__init__(config)
 
@@ -274,7 +274,7 @@ class OpenSourceApp(EmbedChain):
     query(query): finds answer to the given query using vector database and LLM.
     """
 
-    def __init__(self, config):
+    def __init__(self, config = {}):
         print("Loading open source embedding model. This may take some time...")
         if config.get("ef") is None:
             config["ef"] = sentence_transformer_ef

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -241,7 +241,7 @@ class App(EmbedChain):
     query(query): finds answer to the given query using vector database and LLM.
     """
 
-    def __int__(self, config = {}):
+    def __init__(self, config = {}):
         if config.get("ef") is None:
             config["ef"] = openai_ef
         if config.get("default_model") is None:


### PR DESCRIPTION
alternative proposal to replace https://github.com/embedchain/embedchain/pull/100

1. pass `config` object instead of pass separate params (db, ef), which is expected to extend more
2. add `default_model` in config time (could add another method to overwrite in query time though)