### PR TITLE
Prevent clashing chunk IDs

### DIFF
--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -26,7 +26,7 @@ class BaseChunker:
 
             for chunk in chunks:
                 chunk_id = hashlib.sha256((chunk + url).encode()).hexdigest()
-                if (idMap.get(chunk_id) == None):
+                if (idMap.get(chunk_id) is None):
                     idMap[chunk_id] = True
                     ids.append(chunk_id)
                     documents.append(chunk)

--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -1,4 +1,5 @@
 import hashlib
+import random
 
 
 class BaseChunker:
@@ -16,7 +17,7 @@ class BaseChunker:
             chunks = self.text_splitter.split_text(content)
             url = meta_data["url"]
             for chunk in chunks:
-                chunk_id = hashlib.sha256((chunk + url).encode()).hexdigest()
+                chunk_id = hashlib.sha256((chunk + url + str(random.getrandbits(128))).encode()).hexdigest()
                 ids.append(chunk_id)
                 documents.append(chunk)
                 metadatas.append(meta_data)

--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -1,5 +1,4 @@
 import hashlib
-import random
 
 
 class BaseChunker:
@@ -9,6 +8,7 @@ class BaseChunker:
     def create_chunks(self, loader, url):
         documents = []
         ids = []
+        idMap = {}
         datas = loader.load_data(url)
         metadatas = []
         for data in datas:
@@ -17,10 +17,12 @@ class BaseChunker:
             chunks = self.text_splitter.split_text(content)
             url = meta_data["url"]
             for chunk in chunks:
-                chunk_id = hashlib.sha256((chunk + url + str(random.getrandbits(128))).encode()).hexdigest()
-                ids.append(chunk_id)
-                documents.append(chunk)
-                metadatas.append(meta_data)
+                chunk_id = hashlib.sha256((chunk + url).encode()).hexdigest()
+                if (idMap.get(chunk_id) == None):
+                    idMap[chunk_id] = True
+                    ids.append(chunk_id)
+                    documents.append(chunk)
+                    metadatas.append(meta_data)
         return {
             "documents": documents,
             "ids": ids,

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -154,8 +154,6 @@ class EmbedChain:
 
             ids = list(data_dict.keys())
             documents, metadatas = zip(*data_dict.values())
-            documents = list(documents)
-            metadatas = list(metadatas)
 
         self.collection.add(
             documents=documents,

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -138,6 +138,8 @@ class EmbedChain:
 
             ids = list(data_dict.keys())
             documents, metadatas = zip(*data_dict.values())
+            documents = list(documents)
+            metadatas = list(metadatas)
 
         self.collection.add(
             documents=documents,


### PR DESCRIPTION
This PR solves the issue in #64 

With a large enough data set, the clashing occurs relatively often. We can quickly solve this by adding a random bit into the hash function. Alternatively, we can explore using a set for `ids` instead of a list, which might compromise the data. (ie. what if you're trying to use the bot to make up its own language syntax and communicate via only 10 words)