### PR TITLE
Add check to prevent adding duplicate chunks in create_chunks method

### DIFF
--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -17,9 +17,10 @@ class BaseChunker:
             url = meta_data["url"]
             for chunk in chunks:
                 chunk_id = hashlib.sha256((chunk + url).encode()).hexdigest()
-                ids.append(chunk_id)
-                documents.append(chunk)
-                metadatas.append(meta_data)
+                if (chunk_id not in ids):
+                    ids.append(chunk_id)
+                    documents.append(chunk)
+                    metadatas.append(meta_data)
         return {
             "documents": documents,
             "ids": ids,


### PR DESCRIPTION
This PR solves the issue in #64 without affecting vector db functionality.

Added a check in the create_chunks method of the BaseChunker class to prevent adding duplicate chunks.
The check compares the chunk ID, generated using hashlib.sha256, with the existing ids list before appending the chunk to documents.
This ensures that only unique chunks are added to the documents list, preventing duplicates.
The change improves the efficiency and accuracy of chunk processing in the create_chunks method.
