### PR TITLE
fix:pass QueryConfig to dry_run

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -279,7 +279,7 @@ class EmbedChain:
         memory.chat_memory.add_ai_message(answer)
         return answer
 
-    def dry_run(self, input_query):
+    def dry_run(self, input_query, config: QueryConfig = None):
         """
         A dry run does everything except send the resulting prompt to
         the LLM. The purpose is to test the prompt, not the response.


### PR DESCRIPTION
`dry_run` func has `if config is None:` check but not able to pass QueryConfig

related to #167 