### PR TITLE
feat: add method - only count new chunks and print them

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -102,12 +102,14 @@ class EmbedChain:
             ids = list(data_dict.keys())
             documents, metadatas = zip(*data_dict.values())
 
+        chunks_before_addition = self.count()
+
         self.collection.add(
             documents=documents,
             metadatas=list(metadatas),
             ids=ids
         )
-        print(f"Successfully saved {src}. Total chunks count: {self.collection.count()}")
+        print(f"Successfully saved {src}. New chunks count: {self.count() - chunks_before_addition}")
 
     def _format_result(self, results):
         return [


### PR DESCRIPTION
this PR makes it so that the `add` method only prints the number of new chunks, instead of the chunk total.

If users are interested in the total amount of chunks, they can use the `count` method at any time, but I think when you add a web page for instance, you want to know how big it is.