### PR TITLE
[code-quality]: Remove imports from `__init__.py` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,9 @@ Here's the readme example with configuration options.
 ```python
 import os
 from embedchain import App
-from embedchain.config import InitConfig, AddConfig, QueryConfig
+from embedchain.config.AddConfig import AddConfig
+from embedchain.config.InitConfig import InitConfig
+from embedchain.config.QueryConfig import QueryConfig
 from chromadb.utils import embedding_functions
 
 # Example: use your own embedding function
@@ -402,7 +404,7 @@ print(naval_chat_bot.query("What unique capacity does Naval argue humans possess
 Here's the example of using custom prompt template with `.query`
 
 ```python
-from embedchain.config import QueryConfig
+from embedchain.config.QueryConfig import QueryConfig
 from embedchain.embedchain import App
 from string import Template
 import wikipedia
@@ -418,9 +420,9 @@ einstein_chat_template = Template("""
         You are Albert Einstein, a German-born theoretical physicist,
         widely ranked among the greatest and most influential scientists of all time.
 
-        Use the following information about Albert Einstein to respond to 
+        Use the following information about Albert Einstein to respond to
         the human's query acting as Albert Einstein.
-        Context: $context                                
+        Context: $context
 
         Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.
 

--- a/embedchain/__init__.py
+++ b/embedchain/__init__.py
@@ -1,1 +1,1 @@
-from .embedchain import App, OpenSourceApp, PersonApp, PersonOpenSourceApp
+from .embedchain import App, OpenSourceApp, PersonApp, PersonOpenSourceApp  # noqa:F401

--- a/embedchain/config/__init__.py
+++ b/embedchain/config/__init__.py
@@ -1,5 +1,0 @@
-from .AddConfig import AddConfig
-from .BaseConfig import BaseConfig
-from .ChatConfig import ChatConfig
-from .InitConfig import InitConfig
-from .QueryConfig import QueryConfig

--- a/embedchain/data_formatter/__init__.py
+++ b/embedchain/data_formatter/__init__.py
@@ -1,1 +1,0 @@
-from .data_formatter import DataFormatter

--- a/embedchain/data_formatter/data_formatter.py
+++ b/embedchain/data_formatter/data_formatter.py
@@ -4,7 +4,7 @@ from embedchain.chunkers.qna_pair import QnaPairChunker
 from embedchain.chunkers.text import TextChunker
 from embedchain.chunkers.web_page import WebPageChunker
 from embedchain.chunkers.youtube_video import YoutubeVideoChunker
-from embedchain.config import AddConfig
+from embedchain.config.AddConfig import AddConfig
 from embedchain.loaders.docx_file import DocxFileLoader
 from embedchain.loaders.local_qna_pair import LocalQnaPairLoader
 from embedchain.loaders.local_text import LocalTextLoader

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -8,9 +8,11 @@ from dotenv import load_dotenv
 from langchain.docstore.document import Document
 from langchain.memory import ConversationBufferMemory
 
-from embedchain.config import AddConfig, ChatConfig, InitConfig, QueryConfig
-from embedchain.config.QueryConfig import DEFAULT_PROMPT
-from embedchain.data_formatter import DataFormatter
+from embedchain.config.AddConfig import AddConfig
+from embedchain.config.ChatConfig import ChatConfig
+from embedchain.config.InitConfig import InitConfig
+from embedchain.config.QueryConfig import DEFAULT_PROMPT, QueryConfig
+from embedchain.data_formatter.data_formatter import DataFormatter
 
 gpt4all_model = None
 


### PR DESCRIPTION
Fixes https://github.com/embedchain/embedchain/issues/216

Still keeping the `App` related imports in `__init__.py` file for now but we will change that later. 

Tested locally by running tests.

```bash
(base) ➜  embedchain git:(remove-init-imports) make lint 
python3 -m ruff .
(base) ➜  embedchain git:(remove-init-imports) make test 
python3 -m pytest
====================================================================================== test session starts ======================================================================================
platform darwin -- Python 3.11.3, pytest-7.4.0, pluggy-1.2.0
rootdir: /Users/deshrajyadav/Projects/embedchain
plugins: anyio-3.7.1
collected 2 items                                                                                                                                                                               

tests/test_embedchain.py ..                                                                                                                                                               [100%]

======================================================================================= 2 passed in 1.54s =======================================================================================
```