### PR TITLE
chore: add dev dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,4 +33,11 @@ setuptools.setup(
         "sentence_transformers",
         "docx2txt",
     ],
+    extras_require={
+        "dev": [
+            "black",
+            "ruff",
+            "isort"
+        ]
+    }
 )


### PR DESCRIPTION
adds the actual dev dependencies. they will be installed with `make install`.