### PR TITLE
fix: do not create instance in InitConfig `__init__`

### DIFF
--- a/embedchain/config/InitConfig.py
+++ b/embedchain/config/InitConfig.py
@@ -20,27 +20,11 @@ class InitConfig(BaseConfig):
         """
         self._setup_logging(log_level)
 
-        # Embedding Function
-        if ef is None:
-            from chromadb.utils import embedding_functions
-
-            self.ef = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=os.getenv("OPENAI_API_KEY"),
-                organization_id=os.getenv("OPENAI_ORGANIZATION"),
-                model_name="text-embedding-ada-002",
-            )
-        else:
-            self.ef = ef
-
-        if db is None:
-            from embedchain.vectordb.chroma_db import ChromaDB
-
-            self.db = ChromaDB(ef=self.ef, host=host, port=port)
-        else:
-            self.db = db
-
         self.ef = ef
         self.db = db
+
+        self.host = host
+        self.port = port
         return
 
     def _set_embedding_function(self, ef):
@@ -78,8 +62,7 @@ class InitConfig(BaseConfig):
         Sets database to default (`ChromaDb`).
         """
         from embedchain.vectordb.chroma_db import ChromaDB
-
-        self.db = ChromaDB(ef=self.ef)
+        self.db = ChromaDB(ef=self.ef, host=self.host, port=self.port)
 
     def _setup_logging(self, debug_level):
         level = logging.WARNING  # Default level

--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import chromadb
 from chromadb.utils import embedding_functions
@@ -20,6 +21,7 @@ class ChromaDB(BaseVectorDB):
             )
 
         if host and port:
+            logging.info(f"Connecting to ChromaDB server: {host}:{port}")
             self.client_settings = chromadb.config.Settings(
                 chroma_api_impl="rest",
                 chroma_server_host=host,


### PR DESCRIPTION
If the instance is created in the init method, it's created even if you want to use an open source model. That's why you need to create it later, depending on the class of the app. That's what the methods `_set_db_to_default` and `_set_embedding_function_to_default` are for.