### PR TITLE
refactor: no default embedding function

### DIFF
--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -10,14 +10,7 @@ class ChromaDB(BaseVectorDB):
     """Vector database using ChromaDB."""
 
     def __init__(self, db_dir=None, ef=None, host=None, port=None):
-        if ef:
-            self.ef = ef
-        else:
-            self.ef = embedding_functions.OpenAIEmbeddingFunction(
-                api_key=os.getenv("OPENAI_API_KEY"),
-                organization_id=os.getenv("OPENAI_ORGANIZATION"),
-                model_name="text-embedding-ada-002",
-            )
+        self.ef = ef
 
         if host and port:
             self.client_settings = chromadb.config.Settings(


### PR DESCRIPTION
`InitConfig.py` already sets a default embedding function, so there's no reason to have a duplicate in the `ChromaDb` class.