### PR TITLE
chore: add pytest as a dev dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,5 @@ setuptools.setup(
         "docx2txt",
         "pydantic==1.10.8",
     ],
-    extras_require={"dev": ["black", "ruff", "isort"]},
+    extras_require={"dev": ["black", "ruff", "isort", "pytest"]},
 )


### PR DESCRIPTION
I thought this came with python, but apparently it doesn't. So I added it as a dev dependency.