### PR TITLE
chore: remove duplicate dev requirements

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,0 @@
-pip
-black==23.3.0
-isort==5.8.0
-ruff==0.0.277
-pytest==7.4.0


### PR DESCRIPTION
Dev requirements are already in `setup.py`. From there you already install them with `make install`. so this is redundant.