### PR TITLE
fix: escape bs4 parsing error

### DIFF
--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -1,5 +1,8 @@
+import logging
+
 import requests
 from bs4 import BeautifulSoup
+from bs4.builder import ParserRejectedMarkup
 
 from embedchain.loaders.web_page import WebPageLoader
 
@@ -19,6 +22,9 @@ class SitemapLoader:
         soup = BeautifulSoup(response.text, "xml")
         links = [link.text for link in soup.find_all("loc")]
         for link in links:
-            each_load_data = web_page_loader.load_data(link)
-            output.append(each_load_data)
+            try:
+                each_load_data = web_page_loader.load_data(link)
+                output.append(each_load_data)
+            except ParserRejectedMarkup as e:
+                logging.error(f"Failed to parse {link}: {e}")
         return [data[0] for data in output]


### PR DESCRIPTION
I have previously spoken up against escaping errors. But this is different with bulk jobs like the sitemap. You don't want the whole sitemap to stop processing because one site failed.

This error escapes beautiful soup's `ParserRejectedMarkup` error. I found this happens when a file attachment page made it to the sitemap, that's just the attachment and not an html file.

Example output:
```
2023-07-15 00:50:30,466 [root] [ERROR] Failed to parse https://example.com/verify.png: The markup you provided was rejected by the parser. Trying a different parser or a different encoding may help.

Original exception(s) from parser:
 unknown status keyword 'h' in marked section
```