### PR TITLE
fix: Dont initialize chroma and embedding function in init config.

### DIFF
--- a/embedchain/config/InitConfig.py
+++ b/embedchain/config/InitConfig.py
@@ -22,15 +22,8 @@ class InitConfig(BaseConfig):
         :param port: Optional. Port for the database server.
         """
         self._setup_logging(log_level)
-
-        if db is None:
-            from embedchain.vectordb.chroma_db import ChromaDB
-
-            self.db = ChromaDB(ef=ef)
-        else:
-            self.db = db
-
         self.ef = ef
+        self.db = db
         self.host = host
         self.port = port
         self.id = id


### PR DESCRIPTION
## Description

When creating an app using the latest commit, was getting following error

```
ids, embeddings, metadatas, documents = self._validate_embedding_set(
                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Tried the published package and realized that db is getting initialized in init config where the embedding function is not available yet.

## Type of change

Bug fix (non-breaking change which fixes an issue)
