### PR TITLE
fix: Handle divide by zero error when original size is 0

### DIFF
--- a/embedchain/loaders/web_page.py
+++ b/embedchain/loaders/web_page.py
@@ -52,9 +52,10 @@ class WebPageLoader:
         content = clean_string(content)
 
         cleaned_size = len(content)
-        logging.info(
-            f"[{url}] Cleaned page size: {cleaned_size} characters, down from {original_size} (shrunk: {original_size-cleaned_size} chars, {round((1-(cleaned_size/original_size)) * 100, 2)}%)"  # noqa:E501
-        )
+        if original_size != 0:
+            logging.info(
+                f"[{url}] Cleaned page size: {cleaned_size} characters, down from {original_size} (shrunk: {original_size-cleaned_size} chars, {round((1-(cleaned_size/original_size)) * 100, 2)}%)"  # noqa:E501
+            )
 
         meta_data = {
             "url": url,


### PR DESCRIPTION
## Description

Was getting divide by zero error when original size is 0
Fixes # (issue)

## Type of change

Bug fix (non-breaking change which fixes an issue)