### PR TITLE
chore: documentation handling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Please delete options that are not relevant.
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-- [ ] This change requires a documentation update
+- [ ] Documentation update
 
 ## How Has This Been Tested?
 


### PR DESCRIPTION
## Description

I think it's redundant to ask if the change **requires** a documentation update, because that question is already part of the checklist.

Instead what's missing is the option for a type of change the **IS** a documentation update.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
