### PR TITLE
feat: filter sitemap

### DIFF
--- a/docs/advanced/data_types.mdx
+++ b/docs/advanced/data_types.mdx
@@ -30,6 +30,14 @@ To add any web page, use the data_type as `web_page`. Eg:
 app.add('web_page', 'a_valid_web_page_url')
 ```
 
+### Sitemap
+
+Add all web pages from an xml-sitemap. Filters non-text files. Use the data_type as `sitemap`. Eg:
+
+```python
+app.add('sitemap', 'https://example.com/sitemap.xml')
+```
+
 ### Doc file
 
 To add any doc/docx file, use the data_type as `docx`. Eg:

--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from bs4.builder import ParserRejectedMarkup
 
 from embedchain.loaders.web_page import WebPageLoader
+from embedchain.utils import is_readable
 
 
 class SitemapLoader:
@@ -20,11 +21,20 @@ class SitemapLoader:
         response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "xml")
-        links = [link.text for link in soup.find_all("loc")]
+
+        links = [link.text for link in soup.find_all("loc") if link.parent.name == 'url']
+        if len(links) == 0:
+            # Get all <loc> tags as a fallback. This might include images.
+            links = [link.text for link in soup.find_all("loc")]
+
         for link in links:
             try:
                 each_load_data = web_page_loader.load_data(link)
-                output.append(each_load_data)
+
+                if (is_readable(each_load_data[0].get('content'))):
+                    output.append(each_load_data)
+                else:
+                    logging.warning(f"Page is not readable: {link}")
             except ParserRejectedMarkup as e:
                 logging.error(f"Failed to parse {link}: {e}")
         return [data[0] for data in output]

--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -22,7 +22,7 @@ class SitemapLoader:
 
         soup = BeautifulSoup(response.text, "xml")
 
-        links = [link.text for link in soup.find_all("loc") if link.parent.name == 'url']
+        links = [link.text for link in soup.find_all("loc") if link.parent.name == "url"]
         if len(links) == 0:
             # Get all <loc> tags as a fallback. This might include images.
             links = [link.text for link in soup.find_all("loc")]
@@ -31,7 +31,7 @@ class SitemapLoader:
             try:
                 each_load_data = web_page_loader.load_data(link)
 
-                if (is_readable(each_load_data[0].get('content'))):
+                if is_readable(each_load_data[0].get("content")):
                     output.append(each_load_data)
                 else:
                     logging.warning(f"Page is not readable (too many invalid characters): {link}")

--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -34,7 +34,7 @@ class SitemapLoader:
                 if (is_readable(each_load_data[0].get('content'))):
                     output.append(each_load_data)
                 else:
-                    logging.warning(f"Page is not readable: {link}")
+                    logging.warning(f"Page is not readable (too many invalid characters): {link}")
             except ParserRejectedMarkup as e:
                 logging.error(f"Failed to parse {link}: {e}")
         return [data[0] for data in output]

--- a/embedchain/utils.py
+++ b/embedchain/utils.py
@@ -1,4 +1,5 @@
 import re
+import string
 
 
 def clean_string(text):
@@ -33,3 +34,13 @@ def clean_string(text):
     cleaned_text = re.sub(r"([^\w\s])\1*", r"\1", cleaned_text)
 
     return cleaned_text
+
+def is_readable(s):
+    """
+    Heuristic to determine if a string is "readable" (mostly contains printable characters and forms meaningful words)
+    
+    :param s: string
+    :return: True if the string is more than 95% printable.
+    """
+    printable_ratio = sum(c in string.printable for c in s) / len(s)
+    return printable_ratio > 0.95  # 95% of characters are printable

--- a/embedchain/utils.py
+++ b/embedchain/utils.py
@@ -35,10 +35,11 @@ def clean_string(text):
 
     return cleaned_text
 
+
 def is_readable(s):
     """
     Heuristic to determine if a string is "readable" (mostly contains printable characters and forms meaningful words)
-    
+
     :param s: string
     :return: True if the string is more than 95% printable.
     """


### PR DESCRIPTION
## Description

This feature brings great improvements to the way a sitemap is loaded, in two ways.

1. Only <loc> tags that are direct children of <url > tags are loaded. This should filter out <loc>s that are children of <image> tags. SEOPress and other WordPress plugins seem to include images like this.
2. Filters binary pages. If a page contains less than 95% printable characters, it is excluded. This is the case for pictures and other binary files. For any HTML it should be okay. We can adjust this value, but it worked in all my tests.

More about 1:  If for some reason, the sitemap is structured differently where <url> tags are not used (I could not find an example for this), if the list is empty after using the new method, the previous method that adds all <loc>s is used.

I also added docs that did not exist before.

New unit tests should be added after we found a suitable site to test it with.

**I have solved my problem with hitting rate limits. Not loading binary image data reduced the size of the sitemap that gave me issues before by 95%**

Regards #272 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] auto tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
