### PR TITLE
fix: ValueError: ChromaDb cannot be instantiated without an embedding function

### DIFF
--- a/embedchain/apps/PersonApp.py
+++ b/embedchain/apps/PersonApp.py
@@ -20,8 +20,6 @@ class EmbedChainPersonApp:
     def __init__(self, person, config: BaseAppConfig = None):
         self.person = person
         self.person_prompt = f"You are {person}. Whatever you say, you will always say in {person} style."  # noqa:E501
-        if config is None:
-            config = BaseAppConfig()
         super().__init__(config)
 
 


### PR DESCRIPTION
## Description

When using PersonApp or PersonOpenSourceApp the following error occurs:-
ValueError: ChromaDb cannot be instantiated without an embedding function

The error is caused by these 2 lines in EmbedChainPersonApp class:-
```python
if config is None:
    config = BaseAppConfig()
```

Although since the PersonApp inherits from App, and PersonOpenSourceApp inherits from OpenSourceApp, the config is already getting set during their initialization with the super constructor. So the above 2 lines of code can be omitted as they don't provide any functionality that isn't already present, and they cause an error to occur too.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This bug was tested with a small test script as follows:-

```python
naval_chat_bot = PersonApp("Jesse Pinkman")
# naval_chat_bot = PersonOpenSourceApp("Jesse Pinkman")
naval_chat_bot.add("youtube_video", "https://www.youtube.com/watch?v=3qHkcs3kG44")
naval_chat_bot.add("pdf_file", "https://navalmanack.s3.amazonaws.com/Eric-Jorgenson_The-Almanack-of-Naval-Ravikant_Final.pdf")
print(naval_chat_bot.chat("who is naval?"))
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
