### PR TITLE
added data format to metadata internally

### DIFF
--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -5,6 +5,7 @@ class BaseChunker:
     def __init__(self, text_splitter):
         """Initialize the chunker."""
         self.text_splitter = text_splitter
+        self.data_type = None
 
     def create_chunks(self, loader, src):
         """
@@ -22,7 +23,10 @@ class BaseChunker:
         metadatas = []
         for data in datas:
             content = data["content"]
+
             meta_data = data["meta_data"]
+            # add data type to meta data to allow query using data type
+            meta_data["embedchain_data_type"] = self.data_type
             url = meta_data["url"]
 
             chunks = self.get_chunks(content)
@@ -47,3 +51,9 @@ class BaseChunker:
         Override in child class if custom logic.
         """
         return self.text_splitter.split_text(content)
+
+    def set_data_type(self, data_type):
+        """
+        set the data type of chunker
+        """
+        self.data_type = data_type

--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -26,7 +26,7 @@ class BaseChunker:
 
             meta_data = data["meta_data"]
             # add data type to meta data to allow query using data type
-            meta_data["embedchain_data_type"] = self.data_type
+            meta_data["data_type"] = self.data_type
             url = meta_data["url"]
 
             chunks = self.get_chunks(content)

--- a/embedchain/data_formatter/data_formatter.py
+++ b/embedchain/data_formatter/data_formatter.py
@@ -69,6 +69,8 @@ class DataFormatter:
             "docs_site": DocsSiteChunker(config),
         }
         if data_type in chunkers:
-            return chunkers[data_type]
+            chunker = chunkers[data_type]
+            chunker.set_data_type(data_type)
+            return chunker
         else:
             raise ValueError(f"Unsupported data type: {data_type}")


### PR DESCRIPTION
## Description

Added data type to the metadata object.

Fixes #258

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested by logging metadatas_with_metadata variable before pushing to db for a Youtube video:

```
from embedchain import App

app = App()
app.add("youtube_video", "https://youtu.be/ilIefxbSJT8")


```
This adds 'embedchain_data_type': 'youtube_video' to the metadata object for each document
## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
