### PR TITLE
fix: add isort dev dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ pytest = "^7.3.1"
 pytest-mock = "^3.10.0"
 pytest-env = "^0.8.1"
 click = "^8.1.3"
+isort = 5.12.0
 
 [tool.poetry.extras]
 streamlit = ["streamlit"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ pytest = "^7.3.1"
 pytest-mock = "^3.10.0"
 pytest-env = "^0.8.1"
 click = "^8.1.3"
-isort = 5.12.0
+isort = "^5.12.0"
 
 [tool.poetry.extras]
 streamlit = ["streamlit"]


### PR DESCRIPTION
## Description

Isort is needed for code formatting, but it's not installed with poetry.

Sidenote: We should consider Jupyter Notebooks as an extra.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- 
## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
