### PR TITLE
perf: don't instantiate every class in dict

### DIFF
--- a/embedchain/data_formatter/data_formatter.py
+++ b/embedchain/data_formatter/data_formatter.py
@@ -58,18 +58,19 @@ class DataFormatter:
         :return: The chunker for the given data type.
         :raises ValueError: If an unsupported data type is provided.
         """
-        chunkers = {
-            "youtube_video": YoutubeVideoChunker(config),
-            "pdf_file": PdfFileChunker(config),
-            "web_page": WebPageChunker(config),
-            "qna_pair": QnaPairChunker(config),
-            "text": TextChunker(config),
-            "docx": DocxFileChunker(config),
-            "sitemap": WebPageChunker(config),
-            "docs_site": DocsSiteChunker(config),
+        chunker_classes = {
+            "youtube_video": YoutubeVideoChunker,
+            "pdf_file": PdfFileChunker,
+            "web_page": WebPageChunker,
+            "qna_pair": QnaPairChunker,
+            "text": TextChunker,
+            "docx": DocxFileChunker,
+            "sitemap": WebPageChunker,
+            "docs_site": DocsSiteChunker,
         }
-        if data_type in chunkers:
-            chunker = chunkers[data_type]
+        if data_type in chunker_classes:
+            chunker_class = chunker_classes[data_type]
+            chunker = chunker_class(config)
             chunker.set_data_type(data_type)
             return chunker
         else:


### PR DESCRIPTION
## Description

The current dict instantiates every class. This means three things:

1. that memory is wasted on unused classes
2. they are instantiated for no reason (time)
3. if they throw an error, the whole `add` method fails (#306)

Fixes #306

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
