### PR TITLE
Fix default add() and add_local() metadatas (data_type and url) overw…

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -121,7 +121,7 @@ class EmbedChain:
         chunks_before_addition = self.count()
 
         # Add metadata to each document
-        metadatas_with_metadata = [meta or metadata for meta in metadatas]
+        metadatas_with_metadata = [{**meta, **metadata} for meta in metadatas]
 
         self.collection.add(documents=documents, metadatas=list(metadatas_with_metadata), ids=ids)
         print((f"Successfully saved {src}. New chunks count: " f"{self.count() - chunks_before_addition}"))


### PR DESCRIPTION
…riting user-provided metadatas.

## Description

Fix default add() and add_local() metadatas (data_type and url) overwriting user-provided metadatas.

In the load_and_embed method, you're creating a list of metadata dictionaries with this line: metadatas_with_metadata = [meta or metadata for meta in metadatas]. This line is using the or operator to choose between meta (which comes from metadatas) and metadata (which is passed as an argument to the method). If meta is truthy (i.e., not None or not an empty dictionary), it will be chosen over metadata.

If metadatas contains non-empty dictionaries, the metadata argument will be ignored.

To fix this, we merge meta and metadata instead of choosing one over the other:
metadatas_with_metadata = [{**meta, **metadata} for meta in metadatas]

Fixes # (issue)

Fixes broken metadata writing via add() and add_local() methods

## Type of change

Please delete options that are not relevant.

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

was able to retrieve a mix of default metadatas (data_type, url), as well as custom metadatas (title) written via:
add(data_type=''webpage' url='http://www.example.com', metadata={'title':'mytitle'})
and then myAppReference.collection.get().metadatas[0]['title']

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
