### PR TITLE
docs: fix argument out of order

### DIFF
--- a/embedchain/config/apps/AppConfig.py
+++ b/embedchain/config/apps/AppConfig.py
@@ -20,9 +20,9 @@ class AppConfig(BaseAppConfig):
         """
         :param log_level: Optional. (String) Debug level
         ['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'].
-        :param id: Optional. ID of the app. Document metadata will have this id.
         :param host: Optional. Hostname for the database server.
         :param port: Optional. Port for the database server.
+        :param id: Optional. ID of the app. Document metadata will have this id.
         """
         super().__init__(
             log_level=log_level, embedding_fn=AppConfig.default_embedding_function(), host=host, port=port, id=id


### PR DESCRIPTION
## Description

fix arguments being in different order in doc string, compared to actual init method implementation.

It's only a doc string change.

Fixes -

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test

## Checklist:


## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
