### PR TITLE
chore: add release workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,24 +1,36 @@
-name: cd
+name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
 on:
   release:
-    types:
-      - published
-
-permissions:
-  id-token: write
-  contents: read
+    types: [published] # This will trigger the workflow when you create a new release
 
 jobs:
-  publish_to_pypi:
-    name: publish to pypi on new release
+  build-n-publish:
+    name: Build and publish Python 🐍 distributions 📦 to PyPI and TestPyPI
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: JRubics/poetry-publish@v1.16
-        name: Build and publish to PyPI
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          pypi_token: ${{ secrets.PYPI_TOKEN }}
-          ignore_dev_requirements: "yes"
-          repository_url: https://upload.pypi.org/legacy/
-          repository_name: embedchain
+          python-version: 3.8
+
+      - name: Install pep517
+        run: |
+          python -m pip install pep517 --user
+
+      - name: Build a binary wheel and a source tarball
+        run: python -m pep517.build .
+
+      - name: Publish distribution 📦 to Test PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository_url: https://test.pypi.org/legacy/
+
+      - name: Publish distribution 📦 to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.10
 
       - name: Install pep517
         run: |


### PR DESCRIPTION
## Description

Adds a workflow to release on pypi and testpypi when a new version is released on github.

This uses the recommended, new OIDC authentication. This means you don't have to store credentials, **all you have to do is authenticate the workflow from the pypi site**.

You can do so here: https://pypi.org/manage/account/publishing/

The workflow name is `cd.yml`

test.pypi is also included, I'm not sure if it will fail if you don't authenticate it, but I think you might as well do it, it's the same exact thing just at https://test.pypi.org/manage/account/publishing/

Fixes #247 

## Type of change

Please delete options that are not relevant.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
