### PR TITLE
feat: System Message

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -65,9 +65,7 @@ einstein_chat_template = Template("""
         Context: $context
 
         Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.
-
-        Human: $query
-        Albert Einstein:""")
+""")
 query_config = QueryConfig(template=einstein_chat_template)
 queries = [
         "Where did you complete your studies?",

--- a/docs/advanced/query_configuration.mdx
+++ b/docs/advanced/query_configuration.mdx
@@ -58,7 +58,7 @@ _coming soon_
 |option|description|type|default|
 |---|---|---|---|
 |number_documents|Absolute number of documents to pull from the database as context.|int|1
-|template|custom template for prompt. If history is used with query, $history has to be included as well.|Template|Template("Use the following pieces of context to answer the query at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer. \$context Query: \$query Helpful Answer:")|
+|template|custom template for prompt. If history is used, it has to be included with $history.|Template|Template("Use the following pieces of context to answer the query at the end. If you don't know the answer, just say that you don't know, don't try to make up an answer. \$context")|
 |model|name of the model used.|string|depends on app type|
 |temperature|Controls the randomness of the model's output. Higher values (closer to 1) make output more random, lower values make it more deterministic.|float|0|
 |max_tokens|Controls how many tokens are used. Exact implementation (whether it counts prompt and/or response) depends on the model.|int|1000|

--- a/embedchain/apps/App.py
+++ b/embedchain/apps/App.py
@@ -23,9 +23,8 @@ class App(EmbedChain):
 
         super().__init__(config)
 
-    def get_llm_model_answer(self, prompt, config: ChatConfig):
-        messages = []
-        messages.append({"role": "user", "content": prompt})
+    def get_llm_model_answer(self, prompt, system_prompt, config: ChatConfig):
+        messages = [{"role": "user", "content": prompt}, {"role": "system", "content": system_prompt}]
         response = openai.ChatCompletion.create(
             model=config.model or "gpt-3.5-turbo-0613",
             messages=messages,

--- a/embedchain/apps/Llama2App.py
+++ b/embedchain/apps/Llama2App.py
@@ -1,9 +1,18 @@
 import os
+from string import Template
 
 from langchain.llms import Replicate
 
 from embedchain.config import AppConfig
 from embedchain.embedchain import EmbedChain
+
+PROMPT = """
+System: ${system}
+
+User: ${prompt}
+"""
+
+PROMPT_TEMPLATE = Template(PROMPT)
 
 
 class Llama2App(EmbedChain):
@@ -27,10 +36,13 @@ class Llama2App(EmbedChain):
 
         super().__init__(config)
 
-    def get_llm_model_answer(self, prompt, config: AppConfig = None):
+    def get_llm_model_answer(self, prompt: str, system_prompt: str, config: AppConfig = None):
         # TODO: Move the model and other inputs into config
+
+        full_prompt = PROMPT_TEMPLATE.substitute(system=system_prompt, prompt=prompt)
+
         llm = Replicate(
             model="a16z-infra/llama13b-v2-chat:df7690f1994d94e96ad9d568eac121aecf50684a0b0963b25a41cc40061269e5",
             input={"temperature": 0.75, "max_length": 500, "top_p": 1},
         )
-        return llm(prompt)
+        return llm(full_prompt)

--- a/embedchain/apps/OpenSourceApp.py
+++ b/embedchain/apps/OpenSourceApp.py
@@ -1,8 +1,17 @@
 import logging
+from string import Template
 from typing import Iterable, Union
 
 from embedchain.config import ChatConfig, OpenSourceAppConfig
 from embedchain.embedchain import EmbedChain
+
+PROMPT = """
+System: ${system}
+
+User: ${prompt}
+"""
+
+PROMPT_TEMPLATE = Template(PROMPT)
 
 gpt4all_model = None
 
@@ -49,14 +58,16 @@ class OpenSourceApp(EmbedChain):
 
         return GPT4All(model)
 
-    def _get_gpt4all_answer(self, prompt: str, config: ChatConfig) -> Union[str, Iterable]:
+    def _get_gpt4all_answer(self, prompt: str, system_prompt: str, config: ChatConfig) -> Union[str, Iterable]:
         if config.model and config.model != self.config.model:
             raise RuntimeError(
                 "OpenSourceApp does not support switching models at runtime. Please create a new app instance."
             )
 
+        full_prompt = PROMPT_TEMPLATE.substitute(system=system_prompt, prompt=prompt)
+
         response = self.instance.generate(
-            prompt=prompt,
+            prompt=full_prompt,
             streaming=config.stream,
             top_p=config.top_p,
             max_tokens=config.max_tokens,

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -1,6 +1,6 @@
+import textwrap
 from string import Template
 from typing import Optional
-import textwrap
 
 from embedchain.config.QueryConfig import QueryConfig
 

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -1,5 +1,6 @@
 from string import Template
 from typing import Optional
+import textwrap
 
 from embedchain.config.QueryConfig import QueryConfig
 
@@ -13,7 +14,7 @@ DEFAULT_PROMPT = """
   History: $history
 """  # noqa:E501
 
-DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
+DEFAULT_PROMPT_TEMPLATE = Template(textwrap.dedent(DEFAULT_PROMPT).strip())
 
 
 class ChatConfig(QueryConfig):

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -1,4 +1,5 @@
 from string import Template
+from typing import Optional
 
 from embedchain.config.QueryConfig import QueryConfig
 
@@ -7,13 +8,9 @@ DEFAULT_PROMPT = """
   history and context.
   You need to answer the query considering context, chat history and your knowledge base. If you don't know the answer or the answer is neither contained in the context nor in history, then simply say "I don't know".
 
-  $context
+  Context: $context
 
   History: $history
-
-  Query: $query
-
-  Helpful Answer:
 """  # noqa:E501
 
 DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
@@ -27,7 +24,7 @@ class ChatConfig(QueryConfig):
     def __init__(
         self,
         number_documents=None,
-        template: Template = None,
+        template: Optional[Template] = None,
         model=None,
         temperature=None,
         max_tokens=None,

--- a/embedchain/config/QueryConfig.py
+++ b/embedchain/config/QueryConfig.py
@@ -1,6 +1,7 @@
 import re
 from string import Template
 from typing import Optional
+import textwrap
 
 from embedchain.config.BaseConfig import BaseConfig
 
@@ -32,9 +33,9 @@ DEFAULT_SYSTEM_PROMPT = """
   You are a helpful assistant.
 """
 
-DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
-DEFAULT_PROMPT_WITH_HISTORY_TEMPLATE = Template(DEFAULT_PROMPT_WITH_HISTORY)
-DOCS_SITE_PROMPT_TEMPLATE = Template(DOCS_SITE_DEFAULT_PROMPT)
+DEFAULT_PROMPT_TEMPLATE = Template(textwrap.dedent(DEFAULT_PROMPT).strip())
+DEFAULT_PROMPT_WITH_HISTORY_TEMPLATE = Template(textwrap.dedent(DEFAULT_PROMPT_WITH_HISTORY).strip())
+DOCS_SITE_PROMPT_TEMPLATE = Template(textwrap.dedent(DOCS_SITE_DEFAULT_PROMPT).strip())
 query_re = re.compile(r"\$\{*query\}*")
 context_re = re.compile(r"\$\{*context\}*")
 history_re = re.compile(r"\$\{*history\}*")

--- a/embedchain/config/QueryConfig.py
+++ b/embedchain/config/QueryConfig.py
@@ -1,7 +1,7 @@
 import re
+import textwrap
 from string import Template
 from typing import Optional
-import textwrap
 
 from embedchain.config.BaseConfig import BaseConfig
 

--- a/tests/embedchain/test_generate_system_prompt.py
+++ b/tests/embedchain/test_generate_system_prompt.py
@@ -20,17 +20,16 @@ class TestGeneratePrompt(unittest.TestCase):
         the format specified by the template.
         """
         # Setup
-        input_query = "Test query"
         contexts = ["Context 1", "Context 2", "Context 3"]
-        template = "You are a bot. Context: ${context} - Query: ${query} - Helpful answer:"
+        template = "You are a bot. Context: ${context}"
         config = QueryConfig(template=Template(template))
 
         # Execute
-        result = self.app.generate_prompt(input_query, contexts, config)
+        result = self.app.generate_system_prompt(contexts, config)
 
         # Assert
         expected_result = (
-            "You are a bot. Context: Context 1 | Context 2 | Context 3 - Query: Test query - Helpful answer:"
+            "You are a bot. Context: Context 1 | Context 2 | Context 3"
         )
         self.assertEqual(result, expected_result)
 
@@ -43,15 +42,14 @@ class TestGeneratePrompt(unittest.TestCase):
         correctly includes all the contexts and the query.
         """
         # Setup
-        input_query = "Test query"
         contexts = ["Context 1", "Context 2", "Context 3"]
         config = QueryConfig()
 
         # Execute
-        result = self.app.generate_prompt(input_query, contexts, config)
+        result = self.app.generate_system_prompt(contexts, config)
 
         # Assert
-        expected_result = config.template.substitute(context="Context 1 | Context 2 | Context 3", query=input_query)
+        expected_result = config.template.substitute(context="Context 1 | Context 2 | Context 3")
         self.assertEqual(result, expected_result)
 
     def test_generate_prompt_with_history(self):
@@ -59,8 +57,8 @@ class TestGeneratePrompt(unittest.TestCase):
         Test the 'generate_prompt' method with QueryConfig containing a history attribute.
         """
         config = QueryConfig(history=["Past context 1", "Past context 2"])
-        config.template = Template("Context: $context | Query: $query | History: $history")
-        prompt = self.app.generate_prompt("Test query", ["Test context"], config)
+        config.template = Template("Context: $context | History: $history")
+        prompt = self.app.generate_system_prompt(["Test context"], config)
 
-        expected_prompt = "Context: Test context | Query: Test query | History: ['Past context 1', 'Past context 2']"
+        expected_prompt = "Context: Test context | History: ['Past context 1', 'Past context 2']"
         self.assertEqual(prompt, expected_prompt)

--- a/tests/embedchain/test_generate_system_prompt.py
+++ b/tests/embedchain/test_generate_system_prompt.py
@@ -28,9 +28,7 @@ class TestGeneratePrompt(unittest.TestCase):
         result = self.app.generate_system_prompt(contexts, config)
 
         # Assert
-        expected_result = (
-            "You are a bot. Context: Context 1 | Context 2 | Context 3"
-        )
+        expected_result = "You are a bot. Context: Context 1 | Context 2 | Context 3"
         self.assertEqual(result, expected_result)
 
     def test_generate_prompt_with_contexts_list(self):


### PR DESCRIPTION
## Description

Turns the template into a system message. That means the system message is fully configurable using the template string.

**So we have a system message including instructions, context and history. The user message is now just the literal user message.**

Running tests, the quality seems to be about the same.

Llama and GPT4ALL don't seem to support different messages with different roles, so I quite simply said:
```python
PROMPT = """
System: ${system}

User: ${prompt}
"""
```

One change for users: dry run does not include the user message anymore. This is a deliberate choice because it seems redundant, because that's never what you're testing.

One disadvantage: the prompts are always separated. So something like 

```
        Human: $query
        Albert Einstein:
```

doesn't work anymore, because the `$query` can't be in the middle anymore. During my tests, the results were still better, and in the person of Albert Einstein.

I categorize this as breaking, because previous user configs that used `$query` don't work anymore.

PersonApp should still work, judging by the code, but has not been tested.

Fixes #443 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Unit Test
- [X] Test Script (please provide)

```python
from embedchain import App

naval_chat_bot = App()
# Embed Online Resources
naval_chat_bot.add("youtube_video", "https://www.youtube.com/watch?v=3qHkcs3kG44")
naval_chat_bot.add(
    "pdf_file", "https://navalmanack.s3.amazonaws.com/Eric-Jorgenson_The-Almanack-of-Naval-Ravikant_Final.pdf"
)
naval_chat_bot.add("web_page", "https://nav.al/feedback")
naval_chat_bot.add("web_page", "https://nav.al/agi")

# Embed Local Resources
naval_chat_bot.add_local(
    "qna_pair", ("Who is Naval Ravikant?", "Naval Ravikant is an Indian-American entrepreneur and investor.")
)

print(
    naval_chat_bot.query(
        "What unique capacity does Naval argue humans possess when it comes to understanding explanations or concepts?",
        dry_run=True,
    )
)
print(
    naval_chat_bot.query(
        "What unique capacity does Naval argue humans possess when it comes to understanding explanations or concepts?"
    )
)
# Answer: Naval argues that humans possess the unique capacity to understand explanations or concepts to the maximum extent possible in this physical reality.

from embedchain.config import QueryConfig
from embedchain import App
from string import Template
import wikipedia

einstein_chat_bot = App()

# Embed Wikipedia page
page = wikipedia.page("Albert Einstein")
einstein_chat_bot.add("text", page.content)

# Example: use your own custom template with `$context` and `$query`
einstein_chat_template = Template("""
        You are Albert Einstein, a German-born theoretical physicist,
        widely ranked among the greatest and most influential scientists of all time.

        Use the following information about Albert Einstein to respond to
        the human's query acting as Albert Einstein.
        Context: $context

        Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.
""")
query_config = QueryConfig(template=einstein_chat_template)
queries = [
        "Where did you complete your studies?",
        "Why did you win nobel prize?",
        "Why did you divorce your first wife?",
]
for query in queries:
        response = einstein_chat_bot.query(query, query_config)
        print("Query: ", query)
        print("Response: ", response)
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
