### PR TITLE
Added link to C++ build tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Embedchain is a framework to easily create LLM powered bots over any dataset. If
 pip install embedchain
 ```
 
+> On Windows, check you've also installed the [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+
 ## 🔥 Latest
 
 - **[2023/07/19]** Released support for 🦙 `llama2` model. Start creating your `llama2` based bots like this:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Embedchain is a framework to easily create LLM powered bots over any dataset. If
 pip install embedchain
 ```
 
-> On Windows, check you've also installed the [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/).
+> For Windows, you'll also need [C++ build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) installed.
 
 ## 🔥 Latest
 


### PR DESCRIPTION
## Description

Added a simple reminder (with link) to install C++ build tools which should avoid the following installation error regarding `chroma-hnswlib`:

```
C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC\14.36.32532\include\yvals.h(17):
fatal error C1083: Cannot open include file: 'crtdbg.h': No such file or directory

error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\BuildTools
\\VC\\Tools\\MSVC\\14.36.32532\\bin\\HostX86\\x64\\cl.exe' failed with exit code 2
```

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?

- [x] Inspection by eyeball

## Checklist:

N/A

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
