### PR TITLE
[feat]: add support for sending anonymous user_id in telemetry

### DIFF
--- a/tests/embedchain/test_chat.py
+++ b/tests/embedchain/test_chat.py
@@ -7,15 +7,13 @@ from embedchain.config import AppConfig
 
 
 class TestApp(unittest.TestCase):
-    os.environ["OPENAI_API_KEY"] = "test_key"
-
     def setUp(self):
+        os.environ["OPENAI_API_KEY"] = "test_key"
         self.app = App(config=AppConfig(collect_metrics=False))
 
-    @patch("embedchain.embedchain.memory", autospec=True)
     @patch.object(App, "retrieve_from_database", return_value=["Test context"])
     @patch.object(App, "get_answer_from_llm", return_value="Test answer")
-    def test_chat_with_memory(self, mock_answer, mock_retrieve, mock_memory):
+    def test_chat_with_memory(self, mock_get_answer, mock_retrieve):
         """
         This test checks the functionality of the 'chat' method in the App class with respect to the chat history
         memory.
@@ -23,27 +21,17 @@ class TestApp(unittest.TestCase):
         The second call is expected to use the chat history from the first call.
 
         Key assumptions tested:
-        - After the first call, 'memory.chat_memory.add_user_message' and 'memory.chat_memory.add_ai_message' are
             called with correct arguments, adding the correct chat history.
+        - After the first call, 'memory.chat_memory.add_user_message' and 'memory.chat_memory.add_ai_message' are
         - During the second call, the 'chat' method uses the chat history from the first call.
 
         The test isolates the 'chat' method behavior by mocking out 'retrieve_from_database', 'get_answer_from_llm' and
         'memory' methods.
         """
-        mock_memory.load_memory_variables.return_value = {"history": []}
         app = App()
-
-        # First call to chat
         first_answer = app.chat("Test query 1")
         self.assertEqual(first_answer, "Test answer")
-        mock_memory.chat_memory.add_user_message.assert_called_once_with("Test query 1")
-        mock_memory.chat_memory.add_ai_message.assert_called_once_with("Test answer")
-
-        mock_memory.chat_memory.add_user_message.reset_mock()
-        mock_memory.chat_memory.add_ai_message.reset_mock()
-
-        # Second call to chat
+        self.assertEqual(len(app.memory.chat_memory.messages), 2)
         second_answer = app.chat("Test query 2")
         self.assertEqual(second_answer, "Test answer")
-        mock_memory.chat_memory.add_user_message.assert_called_once_with("Test query 2")
-        mock_memory.chat_memory.add_ai_message.assert_called_once_with("Test answer")
+        self.assertEqual(len(app.memory.chat_memory.messages), 4)


### PR DESCRIPTION
## Description

We want to improve our telemetry to improve our package. Hence, adding support for storing the anonymous user_id in telemetry call. **Note that this DOES NOT take any user information from their system.**

We generate a uuid and assign it to the user to track the user event anonymously. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested locally and works fine.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings