### PR TITLE
Feat/serialize deserialize

### DIFF
--- a/embedchain/apps/App.py
+++ b/embedchain/apps/App.py
@@ -2,8 +2,10 @@ import openai
 
 from embedchain.config import AppConfig, ChatConfig
 from embedchain.embedchain import EmbedChain
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 
+@register_deserializable
 class App(EmbedChain):
     """
     The EmbedChain app.

--- a/embedchain/apps/CustomApp.py
+++ b/embedchain/apps/CustomApp.py
@@ -5,9 +5,11 @@ from langchain.schema import BaseMessage
 
 from embedchain.config import ChatConfig, CustomAppConfig
 from embedchain.embedchain import EmbedChain
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.models import Providers
 
 
+@register_deserializable
 class CustomApp(EmbedChain):
     """
     The custom EmbedChain app.

--- a/embedchain/apps/OpenSourceApp.py
+++ b/embedchain/apps/OpenSourceApp.py
@@ -7,8 +7,6 @@ from embedchain.helper_classes.json_serializable import register_deserializable
 
 gpt4all_model = None
 
-from embedchain.helper_classes.json_serializable import register_deserializable
-
 
 @register_deserializable
 class OpenSourceApp(EmbedChain):

--- a/embedchain/apps/OpenSourceApp.py
+++ b/embedchain/apps/OpenSourceApp.py
@@ -3,10 +3,14 @@ from typing import Iterable, Union
 
 from embedchain.config import ChatConfig, OpenSourceAppConfig
 from embedchain.embedchain import EmbedChain
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 gpt4all_model = None
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 
+
+@register_deserializable
 class OpenSourceApp(EmbedChain):
     """
     The OpenSource app.

--- a/embedchain/apps/PersonApp.py
+++ b/embedchain/apps/PersonApp.py
@@ -52,9 +52,6 @@ class EmbedChainPersonApp:
         return config
 
 
-from embedchain.helper_classes.json_serializable import register_deserializable
-
-
 @register_deserializable
 class PersonApp(EmbedChainPersonApp, App):
     """
@@ -69,9 +66,6 @@ class PersonApp(EmbedChainPersonApp, App):
     def chat(self, input_query, config: ChatConfig = None, dry_run=False):
         config = self.add_person_template_to_config(DEFAULT_PROMPT_WITH_HISTORY, config)
         return super().chat(input_query, config, dry_run)
-
-
-from embedchain.helper_classes.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/apps/PersonApp.py
+++ b/embedchain/apps/PersonApp.py
@@ -6,8 +6,10 @@ from embedchain.config import ChatConfig, QueryConfig
 from embedchain.config.apps.BaseAppConfig import BaseAppConfig
 from embedchain.config.QueryConfig import (DEFAULT_PROMPT,
                                            DEFAULT_PROMPT_WITH_HISTORY)
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 
+@register_deserializable
 class EmbedChainPersonApp:
     """
     Base class to create a person bot.
@@ -50,6 +52,10 @@ class EmbedChainPersonApp:
         return config
 
 
+from embedchain.helper_classes.json_serializable import register_deserializable
+
+
+@register_deserializable
 class PersonApp(EmbedChainPersonApp, App):
     """
     The Person app.
@@ -65,6 +71,10 @@ class PersonApp(EmbedChainPersonApp, App):
         return super().chat(input_query, config, dry_run)
 
 
+from embedchain.helper_classes.json_serializable import register_deserializable
+
+
+@register_deserializable
 class PersonOpenSourceApp(EmbedChainPersonApp, OpenSourceApp):
     """
     The Person app.

--- a/embedchain/bots/base.py
+++ b/embedchain/bots/base.py
@@ -1,9 +1,11 @@
 from embedchain import CustomApp
 from embedchain.config import AddConfig, CustomAppConfig, QueryConfig
-from embedchain.helper_classes.json_serializable import JSONSerializable
+from embedchain.helper_classes.json_serializable import (
+    JSONSerializable, register_deserializable)
 from embedchain.models import EmbeddingFunctions, Providers
 
 
+@register_deserializable
 class BaseBot(JSONSerializable):
     def __init__(self, app_config=None):
         if app_config is None:

--- a/embedchain/bots/base.py
+++ b/embedchain/bots/base.py
@@ -1,9 +1,9 @@
 from embedchain import CustomApp
 from embedchain.config import AddConfig, CustomAppConfig, QueryConfig
 from embedchain.models import EmbeddingFunctions, Providers
+from embedchain.helper_classes.json_serializable import JSONSerializable
 
-
-class BaseBot:
+class BaseBot(JSONSerializable):
     def __init__(self, app_config=None):
         if app_config is None:
             app_config = CustomAppConfig(embedding_fn=EmbeddingFunctions.OPENAI, provider=Providers.OPENAI)

--- a/embedchain/bots/base.py
+++ b/embedchain/bots/base.py
@@ -1,7 +1,8 @@
 from embedchain import CustomApp
 from embedchain.config import AddConfig, CustomAppConfig, QueryConfig
-from embedchain.models import EmbeddingFunctions, Providers
 from embedchain.helper_classes.json_serializable import JSONSerializable
+from embedchain.models import EmbeddingFunctions, Providers
+
 
 class BaseBot(JSONSerializable):
     def __init__(self, app_config=None):

--- a/embedchain/bots/poe.py
+++ b/embedchain/bots/poe.py
@@ -6,10 +6,12 @@ from typing import List, Optional
 from fastapi_poe import PoeBot, run
 
 from embedchain.config import QueryConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 from .base import BaseBot
 
 
+@register_deserializable
 class EcPoeBot(BaseBot, PoeBot):
     def __init__(self):
         self.history_length = 5

--- a/embedchain/bots/whatsapp.py
+++ b/embedchain/bots/whatsapp.py
@@ -6,9 +6,12 @@ import sys
 from flask import Flask, request
 from twilio.twiml.messaging_response import MessagingResponse
 
+from embedchain.helper_classes.json_serializable import register_deserializable
+
 from .base import BaseBot
 
 
+@register_deserializable
 class WhatsAppBot(BaseBot):
     def __init__(self):
         super().__init__()

--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -1,7 +1,8 @@
 import hashlib
 
-from embedchain.models.data_type import DataType
 from embedchain.helper_classes.json_serializable import JSONSerializable
+from embedchain.models.data_type import DataType
+
 
 class BaseChunker(JSONSerializable):
     def __init__(self, text_splitter):

--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -1,9 +1,9 @@
 import hashlib
 
 from embedchain.models.data_type import DataType
+from embedchain.helper_classes.json_serializable import JSONSerializable
 
-
-class BaseChunker:
+class BaseChunker(JSONSerializable):
     def __init__(self, text_splitter):
         """Initialize the chunker."""
         self.text_splitter = text_splitter

--- a/embedchain/chunkers/docs_site.py
+++ b/embedchain/chunkers/docs_site.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class DocsSiteChunker(BaseChunker):
     """Chunker for code docs site."""
 

--- a/embedchain/chunkers/docs_site.py
+++ b/embedchain/chunkers/docs_site.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class DocsSiteChunker(BaseChunker):
     """Chunker for code docs site."""

--- a/embedchain/chunkers/docx_file.py
+++ b/embedchain/chunkers/docx_file.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class DocxFileChunker(BaseChunker):
     """Chunker for .docx file."""
 

--- a/embedchain/chunkers/docx_file.py
+++ b/embedchain/chunkers/docx_file.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class DocxFileChunker(BaseChunker):
     """Chunker for .docx file."""

--- a/embedchain/chunkers/notion.py
+++ b/embedchain/chunkers/notion.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class NotionChunker(BaseChunker):
     """Chunker for notion."""
 

--- a/embedchain/chunkers/notion.py
+++ b/embedchain/chunkers/notion.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class NotionChunker(BaseChunker):
     """Chunker for notion."""

--- a/embedchain/chunkers/pdf_file.py
+++ b/embedchain/chunkers/pdf_file.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class PdfFileChunker(BaseChunker):
     """Chunker for PDF file."""
 

--- a/embedchain/chunkers/pdf_file.py
+++ b/embedchain/chunkers/pdf_file.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class PdfFileChunker(BaseChunker):
     """Chunker for PDF file."""

--- a/embedchain/chunkers/qna_pair.py
+++ b/embedchain/chunkers/qna_pair.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class QnaPairChunker(BaseChunker):
     """Chunker for QnA pair."""

--- a/embedchain/chunkers/qna_pair.py
+++ b/embedchain/chunkers/qna_pair.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class QnaPairChunker(BaseChunker):
     """Chunker for QnA pair."""
 

--- a/embedchain/chunkers/text.py
+++ b/embedchain/chunkers/text.py
@@ -4,8 +4,10 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 
+@register_deserializable
 class TextChunker(BaseChunker):
     """Chunker for text."""
 

--- a/embedchain/chunkers/web_page.py
+++ b/embedchain/chunkers/web_page.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class WebPageChunker(BaseChunker):
     """Chunker for web page."""

--- a/embedchain/chunkers/web_page.py
+++ b/embedchain/chunkers/web_page.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class WebPageChunker(BaseChunker):
     """Chunker for web page."""
 

--- a/embedchain/chunkers/youtube_video.py
+++ b/embedchain/chunkers/youtube_video.py
@@ -4,8 +4,9 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class YoutubeVideoChunker(BaseChunker):
     """Chunker for Youtube video."""

--- a/embedchain/chunkers/youtube_video.py
+++ b/embedchain/chunkers/youtube_video.py
@@ -5,7 +5,8 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.AddConfig import ChunkerConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class YoutubeVideoChunker(BaseChunker):
     """Chunker for Youtube video."""
 

--- a/embedchain/config/AddConfig.py
+++ b/embedchain/config/AddConfig.py
@@ -21,9 +21,6 @@ class ChunkerConfig(BaseConfig):
         self.length_function = length_function if length_function else len
 
 
-from embedchain.helper_classes.json_serializable import register_deserializable
-
-
 @register_deserializable
 class LoaderConfig(BaseConfig):
     """
@@ -32,9 +29,6 @@ class LoaderConfig(BaseConfig):
 
     def __init__(self):
         pass
-
-
-from embedchain.helper_classes.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/config/AddConfig.py
+++ b/embedchain/config/AddConfig.py
@@ -1,8 +1,9 @@
 from typing import Callable, Optional
 
 from embedchain.config.BaseConfig import BaseConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class ChunkerConfig(BaseConfig):
     """
@@ -19,7 +20,10 @@ class ChunkerConfig(BaseConfig):
         self.chunk_overlap = chunk_overlap if chunk_overlap else 0
         self.length_function = length_function if length_function else len
 
+
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class LoaderConfig(BaseConfig):
     """
@@ -29,7 +33,10 @@ class LoaderConfig(BaseConfig):
     def __init__(self):
         pass
 
+
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class AddConfig(BaseConfig):
     """

--- a/embedchain/config/AddConfig.py
+++ b/embedchain/config/AddConfig.py
@@ -2,7 +2,8 @@ from typing import Callable, Optional
 
 from embedchain.config.BaseConfig import BaseConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class ChunkerConfig(BaseConfig):
     """
     Config for the chunker used in `add` method
@@ -18,7 +19,8 @@ class ChunkerConfig(BaseConfig):
         self.chunk_overlap = chunk_overlap if chunk_overlap else 0
         self.length_function = length_function if length_function else len
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class LoaderConfig(BaseConfig):
     """
     Config for the chunker used in `add` method
@@ -27,7 +29,8 @@ class LoaderConfig(BaseConfig):
     def __init__(self):
         pass
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class AddConfig(BaseConfig):
     """
     Config for the `add` method.

--- a/embedchain/config/BaseConfig.py
+++ b/embedchain/config/BaseConfig.py
@@ -1,4 +1,6 @@
-class BaseConfig:
+from embedchain.helper_classes.json_serializable import JSONSerializable
+
+class BaseConfig(JSONSerializable):
     """
     Base config.
     """

--- a/embedchain/config/BaseConfig.py
+++ b/embedchain/config/BaseConfig.py
@@ -1,5 +1,6 @@
 from embedchain.helper_classes.json_serializable import JSONSerializable
 
+
 class BaseConfig(JSONSerializable):
     """
     Base config.

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -20,6 +20,8 @@ DEFAULT_PROMPT = """
 DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
 
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class ChatConfig(QueryConfig):
     """

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -19,7 +19,8 @@ DEFAULT_PROMPT = """
 
 DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class ChatConfig(QueryConfig):
     """
     Config for the `chat` method, inherits from `QueryConfig`.

--- a/embedchain/config/ChatConfig.py
+++ b/embedchain/config/ChatConfig.py
@@ -2,6 +2,7 @@ from string import Template
 from typing import Optional
 
 from embedchain.config.QueryConfig import QueryConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 DEFAULT_PROMPT = """
   You are a chatbot having a conversation with a human. You are given chat
@@ -18,8 +19,6 @@ DEFAULT_PROMPT = """
 """  # noqa:E501
 
 DEFAULT_PROMPT_TEMPLATE = Template(DEFAULT_PROMPT)
-
-from embedchain.helper_classes.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/config/QueryConfig.py
+++ b/embedchain/config/QueryConfig.py
@@ -47,7 +47,8 @@ query_re = re.compile(r"\$\{*query\}*")
 context_re = re.compile(r"\$\{*context\}*")
 history_re = re.compile(r"\$\{*history\}*")
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class QueryConfig(BaseConfig):
     """
     Config for the `query` method.

--- a/embedchain/config/QueryConfig.py
+++ b/embedchain/config/QueryConfig.py
@@ -48,6 +48,8 @@ context_re = re.compile(r"\$\{*context\}*")
 history_re = re.compile(r"\$\{*history\}*")
 
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class QueryConfig(BaseConfig):
     """

--- a/embedchain/config/QueryConfig.py
+++ b/embedchain/config/QueryConfig.py
@@ -3,6 +3,7 @@ from string import Template
 from typing import Optional
 
 from embedchain.config.BaseConfig import BaseConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 
 DEFAULT_PROMPT = """
   Use the following pieces of context to answer the query at the end.
@@ -46,8 +47,6 @@ DOCS_SITE_PROMPT_TEMPLATE = Template(DOCS_SITE_DEFAULT_PROMPT)
 query_re = re.compile(r"\$\{*query\}*")
 context_re = re.compile(r"\$\{*context\}*")
 history_re = re.compile(r"\$\{*history\}*")
-
-from embedchain.helper_classes.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/config/apps/AppConfig.py
+++ b/embedchain/config/apps/AppConfig.py
@@ -9,9 +9,11 @@ except RuntimeError:
     use_pysqlite3()
     from chromadb.utils import embedding_functions
 
+from embedchain.helper_classes.json_serializable import register_deserializable
+
 from .BaseAppConfig import BaseAppConfig
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class AppConfig(BaseAppConfig):
     """

--- a/embedchain/config/apps/AppConfig.py
+++ b/embedchain/config/apps/AppConfig.py
@@ -11,7 +11,8 @@ except RuntimeError:
 
 from .BaseAppConfig import BaseAppConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class AppConfig(BaseAppConfig):
     """
     Config to initialize an embedchain custom `App` instance, with extra config options.

--- a/embedchain/config/apps/BaseAppConfig.py
+++ b/embedchain/config/apps/BaseAppConfig.py
@@ -2,9 +2,10 @@ import logging
 
 from embedchain.config.BaseConfig import BaseConfig
 from embedchain.config.vectordbs import ElasticsearchDBConfig
+from embedchain.helper_classes.json_serializable import JSONSerializable
 from embedchain.models import VectorDatabases, VectorDimensions
 
-from embedchain.helper_classes.json_serializable import JSONSerializable
+
 class BaseAppConfig(BaseConfig, JSONSerializable):
     """
     Parent config to initialize an instance of `App`, `OpenSourceApp` or `CustomApp`.

--- a/embedchain/config/apps/BaseAppConfig.py
+++ b/embedchain/config/apps/BaseAppConfig.py
@@ -4,8 +4,8 @@ from embedchain.config.BaseConfig import BaseConfig
 from embedchain.config.vectordbs import ElasticsearchDBConfig
 from embedchain.models import VectorDatabases, VectorDimensions
 
-
-class BaseAppConfig(BaseConfig):
+from embedchain.helper_classes.json_serializable import JSONSerializable
+class BaseAppConfig(BaseConfig, JSONSerializable):
     """
     Parent config to initialize an instance of `App`, `OpenSourceApp` or `CustomApp`.
     """

--- a/embedchain/config/apps/CustomAppConfig.py
+++ b/embedchain/config/apps/CustomAppConfig.py
@@ -12,6 +12,8 @@ from .BaseAppConfig import BaseAppConfig
 load_dotenv()
 
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class CustomAppConfig(BaseAppConfig):
     """

--- a/embedchain/config/apps/CustomAppConfig.py
+++ b/embedchain/config/apps/CustomAppConfig.py
@@ -4,14 +4,13 @@ from chromadb.api.types import Documents, Embeddings
 from dotenv import load_dotenv
 
 from embedchain.config.vectordbs import ElasticsearchDBConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.models import (EmbeddingFunctions, Providers, VectorDatabases,
                                VectorDimensions)
 
 from .BaseAppConfig import BaseAppConfig
 
 load_dotenv()
-
-from embedchain.helper_classes.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/config/apps/CustomAppConfig.py
+++ b/embedchain/config/apps/CustomAppConfig.py
@@ -11,7 +11,8 @@ from .BaseAppConfig import BaseAppConfig
 
 load_dotenv()
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class CustomAppConfig(BaseAppConfig):
     """
     Config to initialize an embedchain custom `App` instance, with extra config options.

--- a/embedchain/config/apps/OpenSourceAppConfig.py
+++ b/embedchain/config/apps/OpenSourceAppConfig.py
@@ -4,7 +4,8 @@ from chromadb.utils import embedding_functions
 
 from .BaseAppConfig import BaseAppConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class OpenSourceAppConfig(BaseAppConfig):
     """
     Config to initialize an embedchain custom `OpenSourceApp` instance, with extra config options.

--- a/embedchain/config/apps/OpenSourceAppConfig.py
+++ b/embedchain/config/apps/OpenSourceAppConfig.py
@@ -2,9 +2,11 @@ from typing import Optional
 
 from chromadb.utils import embedding_functions
 
+from embedchain.helper_classes.json_serializable import register_deserializable
+
 from .BaseAppConfig import BaseAppConfig
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class OpenSourceAppConfig(BaseAppConfig):
     """

--- a/embedchain/config/vectordbs/ElasticsearchDBConfig.py
+++ b/embedchain/config/vectordbs/ElasticsearchDBConfig.py
@@ -2,7 +2,8 @@ from typing import Dict, List, Union
 
 from embedchain.config.BaseConfig import BaseConfig
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class ElasticsearchDBConfig(BaseConfig):
     """
     Config to initialize an elasticsearch client.

--- a/embedchain/config/vectordbs/ElasticsearchDBConfig.py
+++ b/embedchain/config/vectordbs/ElasticsearchDBConfig.py
@@ -1,8 +1,9 @@
 from typing import Dict, List, Union
 
 from embedchain.config.BaseConfig import BaseConfig
-
 from embedchain.helper_classes.json_serializable import register_deserializable
+
+
 @register_deserializable
 class ElasticsearchDBConfig(BaseConfig):
     """

--- a/embedchain/data_formatter/data_formatter.py
+++ b/embedchain/data_formatter/data_formatter.py
@@ -16,9 +16,9 @@ from embedchain.loaders.sitemap import SitemapLoader
 from embedchain.loaders.web_page import WebPageLoader
 from embedchain.loaders.youtube_video import YoutubeVideoLoader
 from embedchain.models.data_type import DataType
+from embedchain.helper_classes.json_serializable import JSONSerializable
 
-
-class DataFormatter:
+class DataFormatter(JSONSerializable):
     """
     DataFormatter is an internal utility class which abstracts the mapping for
     loaders and chunkers to the data_type entered by the user in their

--- a/embedchain/data_formatter/data_formatter.py
+++ b/embedchain/data_formatter/data_formatter.py
@@ -7,6 +7,7 @@ from embedchain.chunkers.text import TextChunker
 from embedchain.chunkers.web_page import WebPageChunker
 from embedchain.chunkers.youtube_video import YoutubeVideoChunker
 from embedchain.config import AddConfig
+from embedchain.helper_classes.json_serializable import JSONSerializable
 from embedchain.loaders.docs_site_loader import DocsSiteLoader
 from embedchain.loaders.docx_file import DocxFileLoader
 from embedchain.loaders.local_qna_pair import LocalQnaPairLoader
@@ -16,7 +17,7 @@ from embedchain.loaders.sitemap import SitemapLoader
 from embedchain.loaders.web_page import WebPageLoader
 from embedchain.loaders.youtube_video import YoutubeVideoLoader
 from embedchain.models.data_type import DataType
-from embedchain.helper_classes.json_serializable import JSONSerializable
+
 
 class DataFormatter(JSONSerializable):
     """

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -19,8 +19,7 @@ from embedchain.config import AddConfig, ChatConfig, QueryConfig
 from embedchain.config.apps.BaseAppConfig import BaseAppConfig
 from embedchain.config.QueryConfig import DOCS_SITE_PROMPT_TEMPLATE
 from embedchain.data_formatter import DataFormatter
-from embedchain.helper_classes.json_serializable import (
-    JSONSerializable, register_deserializable)
+from embedchain.helper_classes.json_serializable import JSONSerializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.models.data_type import DataType
 from embedchain.utils import detect_datatype

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -19,10 +19,11 @@ from embedchain.config import AddConfig, ChatConfig, QueryConfig
 from embedchain.config.apps.BaseAppConfig import BaseAppConfig
 from embedchain.config.QueryConfig import DOCS_SITE_PROMPT_TEMPLATE
 from embedchain.data_formatter import DataFormatter
+from embedchain.helper_classes.json_serializable import JSONSerializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.models.data_type import DataType
 from embedchain.utils import detect_datatype
-from embedchain.helper_classes.json_serializable import JSONSerializable
+
 load_dotenv()
 
 ABS_PATH = os.getcwd()

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -19,7 +19,8 @@ from embedchain.config import AddConfig, ChatConfig, QueryConfig
 from embedchain.config.apps.BaseAppConfig import BaseAppConfig
 from embedchain.config.QueryConfig import DOCS_SITE_PROMPT_TEMPLATE
 from embedchain.data_formatter import DataFormatter
-from embedchain.helper_classes.json_serializable import JSONSerializable
+from embedchain.helper_classes.json_serializable import (
+    JSONSerializable, register_deserializable)
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.models.data_type import DataType
 from embedchain.utils import detect_datatype

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -22,7 +22,7 @@ from embedchain.data_formatter import DataFormatter
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.models.data_type import DataType
 from embedchain.utils import detect_datatype
-
+from embedchain.helper_classes.json_serializable import JSONSerializable
 load_dotenv()
 
 ABS_PATH = os.getcwd()
@@ -32,7 +32,7 @@ CONFIG_DIR = os.path.join(HOME_DIR, ".embedchain")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 
 
-class EmbedChain:
+class EmbedChain(JSONSerializable):
     def __init__(self, config: BaseAppConfig):
         """
         Initializes the EmbedChain instance, sets up a vector DB client and

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -34,10 +34,10 @@ class JSONSerializable:
     This class provides methods to serialize and deserialize objects,
     as well as save serialized objects to a file and load them back.
     """
-
-    # A set of classes that are allowed to be deserialized.
-    # Without this, you could for instance deserialize a bot in a config.
-    _deserializable_classes: set = set()
+    def __init__(self):
+        # A set of classes that are allowed to be deserialized.
+        # Without this, you could for instance deserialize a bot in a config.
+        self._deserializable_classes: set = set()
 
     def serialize(self) -> str:
         """

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -99,7 +99,7 @@ class JSONSerializable:
                 dct.items()
             ):  # We use list() to get a copy of items to avoid dictionary size change during iteration.
                 try:
-                    # Recursive: If the value is an instance of a subclass of JSONSerializable, 
+                    # Recursive: If the value is an instance of a subclass of JSONSerializable,
                     # serialize it using the JSONSerializable serialize method.
                     if isinstance(value, JSONSerializable):
                         serialized_value = value.serialize()
@@ -113,7 +113,6 @@ class JSONSerializable:
             dct["__class__"] = obj.__class__.__name__
             return dct
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
-
 
     @classmethod
     def _auto_decoder(cls, dct: Dict[str, Any]) -> Any:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -1,0 +1,110 @@
+import json
+
+class JSONSerializable:
+    """
+    A class to represent a JSON serializable object.
+
+    This class provides methods to serialize and deserialize objects,
+    as well as save serialized objects to a file and load them back.
+    """
+
+    # A set of classes that are allowed to be deserialized.
+    _deserializable_classes = set()
+
+    def serialize(self):
+        """
+        Serialize the object to a JSON-formatted string.
+
+        Returns:
+            str: A JSON string representation of the object.
+        """
+        try:
+            return json.dumps(self, default=self._auto_encoder, ensure_ascii=False)
+        except Exception as e:
+            print(f"Serialization error: {e}")
+            return "{}"
+
+    @classmethod
+    def deserialize(cls, json_str):
+        """
+        Deserialize a JSON-formatted string to an object.
+
+        Args:
+            json_str (str): A JSON string representation of an object.
+
+        Returns:
+            Object: The deserialized object.
+        """
+        try:
+            return json.loads(json_str, object_hook=cls._auto_decoder)
+        except Exception as e:
+            print(f"Deserialization error: {e}")
+            # Return a default instance in case of failure
+            return cls()
+
+    @staticmethod
+    def _auto_encoder(obj):
+        """
+        Automatically encode an object for JSON serialization.
+
+        Args:
+            obj (Object): The object to be encoded.
+
+        Returns:
+            dict: A dictionary representation of the object.
+        """
+        if hasattr(obj, "__dict__"):
+            dct = obj.__dict__.copy()
+            dct['__class__'] = obj.__class__.__name__
+            return dct
+        raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+    @classmethod
+    def _auto_decoder(cls, dct):
+        """
+        Automatically decode a dictionary to an object during JSON deserialization.
+
+        Args:
+            dct (dict): The dictionary representation of an object.
+
+        Returns:
+            Object: The decoded object or the original dictionary if decoding is not possible.
+        """
+        if '__class__' in dct:
+            class_name = dct.pop('__class__')
+            if class_name not in cls._deserializable_classes:
+                print(f"Deserialization of class '{class_name}' is not allowed.")
+                return {}
+            target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)
+            if target_class:
+                obj = target_class.__new__(target_class)
+                for key, value in dct.items():
+                    default_value = getattr(target_class, key, None)
+                    setattr(obj, key, value or default_value)
+                return obj
+        return dct
+
+    def save_to_file(self, filename):
+        """
+        Save the serialized object to a file.
+
+        Args:
+            filename (str): The path to the file where the object should be saved.
+        """
+        with open(filename, 'w', encoding='utf-8') as f:
+            f.write(self.serialize())
+
+    @classmethod
+    def load_from_file(cls, filename):
+        """
+        Load and deserialize an object from a file.
+
+        Args:
+            filename (str): The path to the file from which the object should be loaded.
+
+        Returns:
+            Object: The deserialized object.
+        """
+        with open(filename, 'r', encoding='utf-8') as f:
+            json_str = f.read()
+            return cls.deserialize(json_str)

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -1,12 +1,13 @@
 import json
-from typing import Any, Dict, Type, Union, TypeVar
+from typing import Any, Dict, Type, TypeVar, Union
 
-T = TypeVar('T', bound='JSONSerializable')
+T = TypeVar("T", bound="JSONSerializable")
+
 
 def register_deserializable(cls: Type[T]) -> Type[T]:
     """
     A class decorator to register a class as deserializable.
-    
+
     When a class is decorated with @register_deserializable, it becomes
     a part of the set of classes that the JSONSerializable class can
     deserialize.
@@ -34,6 +35,7 @@ class JSONSerializable:
     This class provides methods to serialize and deserialize objects,
     as well as save serialized objects to a file and load them back.
     """
+
     def __init__(self):
         # A set of classes that are allowed to be deserialized.
         # Without this, you could for instance deserialize a bot in a config.
@@ -83,7 +85,7 @@ class JSONSerializable:
         """
         if hasattr(obj, "__dict__"):
             dct = obj.__dict__.copy()
-            dct['__class__'] = obj.__class__.__name__
+            dct["__class__"] = obj.__class__.__name__
             return dct
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
@@ -98,7 +100,7 @@ class JSONSerializable:
         Returns:
             Object: The decoded object or the original dictionary if decoding is not possible.
         """
-        class_name = dct.pop('__class__', None)
+        class_name = dct.pop("__class__", None)
         if class_name:
             if class_name not in cls._deserializable_classes:
                 print(f"Deserialization of class '{class_name}' is not allowed.")
@@ -119,7 +121,7 @@ class JSONSerializable:
         Args:
             filename (str): The path to the file where the object should be saved.
         """
-        with open(filename, 'w', encoding='utf-8') as f:
+        with open(filename, "w", encoding="utf-8") as f:
             f.write(self.serialize())
 
     @classmethod
@@ -133,16 +135,16 @@ class JSONSerializable:
         Returns:
             Object: The deserialized object.
         """
-        with open(filename, 'r', encoding='utf-8') as f:
+        with open(filename, "r", encoding="utf-8") as f:
             json_str = f.read()
             return cls.deserialize(json_str)
-        
+
     @classmethod
     def register_class_as_deserializable(cls, target_class: Type[T]) -> None:
         """
         Register a class as deserializable.
 
-        This method adds the target class to the set of classes that 
+        This method adds the target class to the set of classes that
         the JSONSerializable system recognizes and allows to be deserialized.
 
         Args:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -98,8 +98,8 @@ class JSONSerializable:
         Returns:
             Object: The decoded object or the original dictionary if decoding is not possible.
         """
-        if '__class__' in dct:
-            class_name = dct.pop('__class__')
+        class_name = dct.pop('__class__', None)
+        if class_name:
             if class_name not in cls._deserializable_classes:
                 print(f"Deserialization of class '{class_name}' is not allowed.")
                 return {}

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -66,6 +66,10 @@ class JSONSerializable:
     def deserialize(cls, json_str: str) -> Any:
         """
         Deserialize a JSON-formatted string to an object.
+        Note: This *returns* an instance, it's not automatically loaded on the calling class.
+
+        Example:
+            app = App.deserialize(json_str)
 
         Args:
             json_str (str): A JSON string representation of an object.
@@ -125,7 +129,9 @@ class JSONSerializable:
                 logging.error(f"`{class_name}` has no registry of allowed deserializations.")
                 return {}
             if class_name not in {cl.__name__ for cl in cls._deserializable_classes}:
-                logging.warning(f"Deserialization of class '{class_name}' is not allowed.")
+                logging.warning(
+                    f"Deserialization of class '{class_name}' is not allowed."
+                )
                 return {}
             target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)
             if target_class:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -1,5 +1,21 @@
 import json
-from typing import Any, Dict, Type, Union
+from typing import Any, Dict, Type, Union, TypeVar
+
+T = TypeVar('T', bound='JSONSerializable')
+
+def register_deserializable(cls: Type[T]) -> Type[T]:
+    """
+    A class decorator to register a class as deserializable.
+
+    Args:
+        cls (Type): The class to be registered.
+
+    Returns:
+        Type: The same class, after registration.
+    """
+    JSONSerializable.register_class_as_deserializable(cls)
+    return cls
+
 
 class JSONSerializable:
     """
@@ -10,6 +26,7 @@ class JSONSerializable:
     """
 
     # A set of classes that are allowed to be deserialized.
+    # Without this, you could for instance deserialize a bot in a config.
     _deserializable_classes: set = set()
 
     def serialize(self) -> str:
@@ -109,3 +126,16 @@ class JSONSerializable:
         with open(filename, 'r', encoding='utf-8') as f:
             json_str = f.read()
             return cls.deserialize(json_str)
+        
+    @classmethod
+    def register_class_as_deserializable(cls, target_class: Type[T]) -> None:
+        """
+        Register a class as deserializable.
+
+        This method adds the target class to the set of classes that 
+        the JSONSerializable system recognizes and allows to be deserialized.
+
+        Args:
+            target_class (Type): The class to be registered.
+        """
+        cls._deserializable_classes.add(target_class)

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -85,6 +85,12 @@ class JSONSerializable:
         """
         if hasattr(obj, "__dict__"):
             dct = obj.__dict__.copy()
+            for key, value in list(dct.items()):  # We use list() to get a copy of items to avoid dictionary size change during iteration.
+                try:
+                    json.dumps(value)  # Try to serialize the value.
+                except TypeError:
+                    del dct[key]  # If it fails, remove the key-value pair from the dictionary.
+            
             dct["__class__"] = obj.__class__.__name__
             return dct
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -119,9 +119,6 @@ class JSONSerializable:
             Object: The decoded object or the original dictionary if decoding is not possible.
         """
         class_name = dct.pop("__class__", None)
-        print("Class Name:",class_name)
-        for x in [cl.__name__ for cl in cls._deserializable_classes]:
-            print(x)
         if class_name:
             if not hasattr(cls, "_deserializable_classes"):  # Additional safety check
                 raise AttributeError(f"`{class_name}` has no registry of allowed deserializations.")

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -124,9 +124,9 @@ class JSONSerializable:
                 # If this error occurs, the decorator at the very start of this file has not been added.
                 logging.error(f"`{class_name}` has no registry of allowed deserializations.")
                 return {}
-            if class_name not in cls._deserializable_classes:
+            if class_name not in {cl.__name__ for cl in cls._deserializable_classes}:
                 logging.warning(
-                    f"Deserialization of class '{class_name}' is not allowed. Allowed: {cls._deserializable_classes}"
+                    f"Deserialization of class '{class_name}' is not allowed. Allowed: {[cl.__name__ for cl in cls._deserializable_classes]}"
                 )
                 return {}
             target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -99,13 +99,21 @@ class JSONSerializable:
                 dct.items()
             ):  # We use list() to get a copy of items to avoid dictionary size change during iteration.
                 try:
-                    json.dumps(value)  # Try to serialize the value.
+                    # Recursive: If the value is an instance of a subclass of JSONSerializable, 
+                    # serialize it using the JSONSerializable serialize method.
+                    if isinstance(value, JSONSerializable):
+                        serialized_value = value.serialize()
+                        # The value is stored as a serialized string.
+                        dct[key] = json.loads(serialized_value)
+                    else:
+                        json.dumps(value)  # Try to serialize the value.
                 except TypeError:
                     del dct[key]  # If it fails, remove the key-value pair from the dictionary.
 
             dct["__class__"] = obj.__class__.__name__
             return dct
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
 
     @classmethod
     def _auto_decoder(cls, dct: Dict[str, Any]) -> Any:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -129,9 +129,7 @@ class JSONSerializable:
                 logging.error(f"`{class_name}` has no registry of allowed deserializations.")
                 return {}
             if class_name not in {cl.__name__ for cl in cls._deserializable_classes}:
-                logging.warning(
-                    f"Deserialization of class '{class_name}' is not allowed."
-                )
+                logging.warning(f"Deserialization of class '{class_name}' is not allowed.")
                 return {}
             target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)
             if target_class:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -69,7 +69,7 @@ class JSONSerializable:
         try:
             return json.loads(json_str, object_hook=cls._auto_decoder)
         except Exception as e:
-            print(f"Deserialization error: {e}")
+            logging.error(f"Deserialization error: {e}")
             # Return a default instance in case of failure
             return cls()
 

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -6,6 +6,16 @@ T = TypeVar('T', bound='JSONSerializable')
 def register_deserializable(cls: Type[T]) -> Type[T]:
     """
     A class decorator to register a class as deserializable.
+    
+    When a class is decorated with @register_deserializable, it becomes
+    a part of the set of classes that the JSONSerializable class can
+    deserialize.
+
+    Example:
+        @register_deserializable
+        class ChildClass(JSONSerializable):
+            def __init__(self, ...):
+                # initialization logic
 
     Args:
         cls (Type): The class to be registered.

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -63,6 +63,7 @@ class JSONSerializable:
     def deserialize(cls, json_str: str) -> Any:
         """
         Deserialize a JSON-formatted string to an object.
+        If it fails, a default class is returned instead.
         Note: This *returns* an instance, it's not automatically loaded on the calling class.
 
         Example:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -1,4 +1,5 @@
 import json
+from typing import Any, Dict, Type, Union
 
 class JSONSerializable:
     """
@@ -9,9 +10,9 @@ class JSONSerializable:
     """
 
     # A set of classes that are allowed to be deserialized.
-    _deserializable_classes = set()
+    _deserializable_classes: set = set()
 
-    def serialize(self):
+    def serialize(self) -> str:
         """
         Serialize the object to a JSON-formatted string.
 
@@ -25,7 +26,7 @@ class JSONSerializable:
             return "{}"
 
     @classmethod
-    def deserialize(cls, json_str):
+    def deserialize(cls, json_str: str) -> Any:
         """
         Deserialize a JSON-formatted string to an object.
 
@@ -43,7 +44,7 @@ class JSONSerializable:
             return cls()
 
     @staticmethod
-    def _auto_encoder(obj):
+    def _auto_encoder(obj: Any) -> Union[Dict[str, Any], None]:
         """
         Automatically encode an object for JSON serialization.
 
@@ -60,7 +61,7 @@ class JSONSerializable:
         raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
 
     @classmethod
-    def _auto_decoder(cls, dct):
+    def _auto_decoder(cls, dct: Dict[str, Any]) -> Any:
         """
         Automatically decode a dictionary to an object during JSON deserialization.
 
@@ -84,7 +85,7 @@ class JSONSerializable:
                 return obj
         return dct
 
-    def save_to_file(self, filename):
+    def save_to_file(self, filename: str) -> None:
         """
         Save the serialized object to a file.
 
@@ -95,7 +96,7 @@ class JSONSerializable:
             f.write(self.serialize())
 
     @classmethod
-    def load_from_file(cls, filename):
+    def load_from_file(cls, filename: str) -> Any:
         """
         Load and deserialize an object from a file.
 

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -125,9 +125,7 @@ class JSONSerializable:
                 logging.error(f"`{class_name}` has no registry of allowed deserializations.")
                 return {}
             if class_name not in {cl.__name__ for cl in cls._deserializable_classes}:
-                logging.warning(
-                    f"Deserialization of class '{class_name}' is not allowed. Allowed: {[cl.__name__ for cl in cls._deserializable_classes]}"
-                )
+                logging.warning(f"Deserialization of class '{class_name}' is not allowed.")
                 return {}
             target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)
             if target_class:

--- a/embedchain/helper_classes/json_serializable.py
+++ b/embedchain/helper_classes/json_serializable.py
@@ -118,13 +118,14 @@ class JSONSerializable:
             Object: The decoded object or the original dictionary if decoding is not possible.
         """
         class_name = dct.pop("__class__", None)
+        print("Class Name:",class_name)
+        for x in [cl.__name__ for cl in cls._deserializable_classes]:
+            print(x)
         if class_name:
             if not hasattr(cls, "_deserializable_classes"):  # Additional safety check
-                logging.error(f"`{class_name}` has no registry of allowed deserializations.")
-                return {}
+                raise AttributeError(f"`{class_name}` has no registry of allowed deserializations.")
             if class_name not in {cl.__name__ for cl in cls._deserializable_classes}:
-                logging.warning(f"Deserialization of class '{class_name}' is not allowed.")
-                return {}
+                raise KeyError(f"Deserialization of class `{class_name}` is not allowed.")
             target_class = next((cl for cl in cls._deserializable_classes if cl.__name__ == class_name), None)
             if target_class:
                 obj = target_class.__new__(target_class)

--- a/embedchain/loaders/base_loader.py
+++ b/embedchain/loaders/base_loader.py
@@ -1,5 +1,6 @@
 from embedchain.helper_classes.json_serializable import JSONSerializable
 
+
 class BaseLoader(JSONSerializable):
     def __init__(self):
         pass

--- a/embedchain/loaders/base_loader.py
+++ b/embedchain/loaders/base_loader.py
@@ -1,4 +1,6 @@
-class BaseLoader:
+from embedchain.helper_classes.json_serializable import JSONSerializable
+
+class BaseLoader(JSONSerializable):
     def __init__(self):
         pass
 

--- a/embedchain/loaders/docs_site_loader.py
+++ b/embedchain/loaders/docs_site_loader.py
@@ -6,7 +6,8 @@ from bs4 import BeautifulSoup
 
 from embedchain.loaders.base_loader import BaseLoader
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class DocsSiteLoader(BaseLoader):
     def __init__(self):
         self.visited_links = set()

--- a/embedchain/loaders/docs_site_loader.py
+++ b/embedchain/loaders/docs_site_loader.py
@@ -4,9 +4,10 @@ from urllib.parse import urljoin, urlparse
 import requests
 from bs4 import BeautifulSoup
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class DocsSiteLoader(BaseLoader):
     def __init__(self):

--- a/embedchain/loaders/docx_file.py
+++ b/embedchain/loaders/docx_file.py
@@ -2,7 +2,8 @@ from langchain.document_loaders import Docx2txtLoader
 
 from embedchain.loaders.base_loader import BaseLoader
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class DocxFileLoader(BaseLoader):
     def load_data(self, url):
         """Load data from a .docx file."""

--- a/embedchain/loaders/docx_file.py
+++ b/embedchain/loaders/docx_file.py
@@ -1,8 +1,9 @@
 from langchain.document_loaders import Docx2txtLoader
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class DocxFileLoader(BaseLoader):
     def load_data(self, url):

--- a/embedchain/loaders/local_qna_pair.py
+++ b/embedchain/loaders/local_qna_pair.py
@@ -1,6 +1,7 @@
 from embedchain.loaders.base_loader import BaseLoader
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class LocalQnaPairLoader(BaseLoader):
     def load_data(self, content):
         """Load data from a local QnA pair."""

--- a/embedchain/loaders/local_qna_pair.py
+++ b/embedchain/loaders/local_qna_pair.py
@@ -1,6 +1,7 @@
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class LocalQnaPairLoader(BaseLoader):
     def load_data(self, content):

--- a/embedchain/loaders/local_text.py
+++ b/embedchain/loaders/local_text.py
@@ -1,6 +1,7 @@
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class LocalTextLoader(BaseLoader):
     def load_data(self, content):

--- a/embedchain/loaders/local_text.py
+++ b/embedchain/loaders/local_text.py
@@ -1,6 +1,7 @@
 from embedchain.loaders.base_loader import BaseLoader
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class LocalTextLoader(BaseLoader):
     def load_data(self, content):
         """Load data from a local text file."""

--- a/embedchain/loaders/notion.py
+++ b/embedchain/loaders/notion.py
@@ -10,7 +10,8 @@ except ImportError:
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class NotionLoader(BaseLoader):
     def load_data(self, source):
         """Load data from a PDF file."""

--- a/embedchain/loaders/notion.py
+++ b/embedchain/loaders/notion.py
@@ -7,10 +7,11 @@ except ImportError:
     raise ImportError("Notion requires extra dependencies. Install with `pip install embedchain[community]`") from None
 
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class NotionLoader(BaseLoader):
     def load_data(self, source):

--- a/embedchain/loaders/pdf_file.py
+++ b/embedchain/loaders/pdf_file.py
@@ -3,7 +3,8 @@ from langchain.document_loaders import PyPDFLoader
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class PdfFileLoader(BaseLoader):
     def load_data(self, url):
         """Load data from a PDF file."""

--- a/embedchain/loaders/pdf_file.py
+++ b/embedchain/loaders/pdf_file.py
@@ -1,9 +1,10 @@
 from langchain.document_loaders import PyPDFLoader
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class PdfFileLoader(BaseLoader):
     def load_data(self, url):

--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -8,7 +8,8 @@ from embedchain.loaders.base_loader import BaseLoader
 from embedchain.loaders.web_page import WebPageLoader
 from embedchain.utils import is_readable
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class SitemapLoader(BaseLoader):
     def load_data(self, sitemap_url):
         """

--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -4,11 +4,12 @@ import requests
 from bs4 import BeautifulSoup
 from bs4.builder import ParserRejectedMarkup
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.loaders.web_page import WebPageLoader
 from embedchain.utils import is_readable
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class SitemapLoader(BaseLoader):
     def load_data(self, sitemap_url):

--- a/embedchain/loaders/web_page.py
+++ b/embedchain/loaders/web_page.py
@@ -3,10 +3,11 @@ import logging
 import requests
 from bs4 import BeautifulSoup
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class WebPageLoader(BaseLoader):
     def load_data(self, url):

--- a/embedchain/loaders/web_page.py
+++ b/embedchain/loaders/web_page.py
@@ -6,7 +6,8 @@ from bs4 import BeautifulSoup
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class WebPageLoader(BaseLoader):
     def load_data(self, url):
         """Load data from a web page."""

--- a/embedchain/loaders/youtube_video.py
+++ b/embedchain/loaders/youtube_video.py
@@ -1,9 +1,10 @@
 from langchain.document_loaders import YoutubeLoader
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class YoutubeVideoLoader(BaseLoader):
     def load_data(self, url):

--- a/embedchain/loaders/youtube_video.py
+++ b/embedchain/loaders/youtube_video.py
@@ -3,7 +3,8 @@ from langchain.document_loaders import YoutubeLoader
 from embedchain.loaders.base_loader import BaseLoader
 from embedchain.utils import clean_string
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class YoutubeVideoLoader(BaseLoader):
     def load_data(self, url):
         """Load data from a Youtube video."""

--- a/embedchain/vectordb/base_vector_db.py
+++ b/embedchain/vectordb/base_vector_db.py
@@ -1,4 +1,6 @@
-class BaseVectorDB:
+from embedchain.helper_classes.json_serializable import JSONSerializable
+
+class BaseVectorDB(JSONSerializable):
     """Base class for vector database."""
 
     def __init__(self):

--- a/embedchain/vectordb/base_vector_db.py
+++ b/embedchain/vectordb/base_vector_db.py
@@ -1,5 +1,6 @@
 from embedchain.helper_classes.json_serializable import JSONSerializable
 
+
 class BaseVectorDB(JSONSerializable):
     """Base class for vector database."""
 

--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -16,7 +16,8 @@ from chromadb.config import Settings
 
 from embedchain.vectordb.base_vector_db import BaseVectorDB
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class ChromaDB(BaseVectorDB):
     """Vector database using ChromaDB."""
 

--- a/embedchain/vectordb/chroma_db.py
+++ b/embedchain/vectordb/chroma_db.py
@@ -14,9 +14,10 @@ except RuntimeError:
 
 from chromadb.config import Settings
 
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.vectordb.base_vector_db import BaseVectorDB
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class ChromaDB(BaseVectorDB):
     """Vector database using ChromaDB."""

--- a/embedchain/vectordb/elasticsearch_db.py
+++ b/embedchain/vectordb/elasticsearch_db.py
@@ -12,7 +12,8 @@ from embedchain.config import ElasticsearchDBConfig
 from embedchain.models.VectorDimensions import VectorDimensions
 from embedchain.vectordb.base_vector_db import BaseVectorDB
 
-
+from embedchain.helper_classes.json_serializable import register_deserializable
+@register_deserializable
 class ElasticsearchDB(BaseVectorDB):
     def __init__(
         self,

--- a/embedchain/vectordb/elasticsearch_db.py
+++ b/embedchain/vectordb/elasticsearch_db.py
@@ -9,10 +9,11 @@ except ImportError:
     ) from None
 
 from embedchain.config import ElasticsearchDBConfig
+from embedchain.helper_classes.json_serializable import register_deserializable
 from embedchain.models.VectorDimensions import VectorDimensions
 from embedchain.vectordb.base_vector_db import BaseVectorDB
 
-from embedchain.helper_classes.json_serializable import register_deserializable
+
 @register_deserializable
 class ElasticsearchDB(BaseVectorDB):
     def __init__(

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -1,0 +1,38 @@
+import random
+import unittest
+
+from embedchain.helper_classes.json_serializable import (
+    JSONSerializable, register_deserializable)
+
+
+class TestJsonSerializable(unittest.TestCase):
+    """Test that the datatype detection is working, based on the input."""
+
+    def test_base_function(self):
+        """Test that the base premise of serialization and deserealization is working"""
+
+        @register_deserializable
+        class TestClass(JSONSerializable):
+            def __init__(self):
+                self.rng = random.random()
+
+            def bark(self):
+                print(self.rng)
+
+        original_class = TestClass()
+        serial = original_class.serialize()
+
+        # Negative test to show that a new class does not have the same random number.
+        negative_test_class = TestClass()
+        self.assertNotEqual(original_class.rng, negative_test_class.rng)
+
+        # Test to show that a deserialized class has the same random number.
+        positive_test_class: TestClass = TestClass().deserialize(serial)
+        self.assertEqual(original_class.rng, positive_test_class.rng)
+        self.assertTrue(isinstance(positive_test_class, TestClass))
+
+        # Test that it works as a static method too.
+        positive_test_class: TestClass = TestClass.deserialize(serial)
+        self.assertEqual(original_class.rng, positive_test_class.rng)
+
+    # TODO: There's no reason it shouldn't work, but serialization to and from file should be tested too.

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -66,3 +66,4 @@ class TestJsonSerializable(unittest.TestCase):
         new_app: App = App.deserialize(s)
         # The id of the new app is the same as the first one.
         self.assertEqual(random_id, new_app.config.id)
+        # TODO: test deeper recursion

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -33,3 +33,22 @@ class TestJsonSerializable(unittest.TestCase):
         self.assertEqual(original_class.rng, positive_test_class.rng)
 
     # TODO: There's no reason it shouldn't work, but serialization to and from file should be tested too.
+
+    def test_registration_required(self):
+        """Test that registration is required, and that without registration the default class is returned."""
+        class SecondTestClass(JSONSerializable):
+            def __init__(self):
+                self.default = True
+
+        app = SecondTestClass()
+        # Make not default
+        app.default = False
+        # Serialize
+        serial = app.serialize()
+        # Deserialize. Due to the way errors are handled, it will not fail but return a default class.
+        app: SecondTestClass = SecondTestClass().deserialize(serial)
+        self.assertTrue(app.default)
+        # If we register and try again with the same serial, it should work
+        SecondTestClass.register_class_as_deserializable(SecondTestClass)
+        app: SecondTestClass = SecondTestClass().deserialize(serial)
+        self.assertFalse(app.default)

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -16,9 +16,6 @@ class TestJsonSerializable(unittest.TestCase):
             def __init__(self):
                 self.rng = random.random()
 
-            def bark(self):
-                print(self.rng)
-
         original_class = TestClass()
         serial = original_class.serialize()
 

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -1,10 +1,10 @@
 import random
 import unittest
-from embedchain.config import AppConfig
 
+from embedchain import App
+from embedchain.config import AppConfig
 from embedchain.helper_classes.json_serializable import (
     JSONSerializable, register_deserializable)
-from embedchain import App
 
 
 class TestJsonSerializable(unittest.TestCase):
@@ -38,6 +38,7 @@ class TestJsonSerializable(unittest.TestCase):
 
     def test_registration_required(self):
         """Test that registration is required, and that without registration the default class is returned."""
+
         class SecondTestClass(JSONSerializable):
             def __init__(self):
                 self.default = True
@@ -61,7 +62,7 @@ class TestJsonSerializable(unittest.TestCase):
         config = AppConfig(id=random_id)
         # config class is set under app.config.
         app = App(config=config)
-        # Without recursion it would just be <embedchain.config.apps.OpenSourceAppConfig.OpenSourceAppConfig object at x> 
+        # Without recursion it would just be <embedchain.config.apps.OpenSourceAppConfig.OpenSourceAppConfig object at x>
         s = app.serialize()
         new_app: App = App.deserialize(s)
         # The id of the new app is the same as the first one.

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -62,7 +62,7 @@ class TestJsonSerializable(unittest.TestCase):
         config = AppConfig(id=random_id)
         # config class is set under app.config.
         app = App(config=config)
-        # Without recursion it would just be <embedchain.config.apps.OpenSourceAppConfig.OpenSourceAppConfig object at x>
+        # w/o recursion it would just be <embedchain.config.apps.OpenSourceAppConfig.OpenSourceAppConfig object at x>
         s = app.serialize()
         new_app: App = App.deserialize(s)
         # The id of the new app is the same as the first one.

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -1,8 +1,10 @@
 import random
 import unittest
+from embedchain.config import AppConfig
 
 from embedchain.helper_classes.json_serializable import (
     JSONSerializable, register_deserializable)
+from embedchain import App
 
 
 class TestJsonSerializable(unittest.TestCase):
@@ -52,3 +54,15 @@ class TestJsonSerializable(unittest.TestCase):
         SecondTestClass.register_class_as_deserializable(SecondTestClass)
         app: SecondTestClass = SecondTestClass().deserialize(serial)
         self.assertFalse(app.default)
+
+    def test_recursive(self):
+        """Test recursiveness with the real app"""
+        random_id = str(random.random())
+        config = AppConfig(id=random_id)
+        # config class is set under app.config.
+        app = App(config=config)
+        # Without recursion it would just be <embedchain.config.apps.OpenSourceAppConfig.OpenSourceAppConfig object at x> 
+        s = app.serialize()
+        new_app: App = App.deserialize(s)
+        # The id of the new app is the same as the first one.
+        self.assertEqual(random_id, new_app.config.id)


### PR DESCRIPTION
## Description

Adds support for serialization and deserialization.

This is a deeply rooted change, it does not break anything, but it changes the way we have to go forward. In the future, we have to decorate all classes.

With `json_string = app.serialize()` you can get a json string. You can store this, send it or whatever. Then, when you're ready you can take the json string and load it to get back the exact same object, with `app = App.deserialize(json_string)`

* it is recursive, so if you serialize app, it also serializes the config. same with deserialization
* tests have been added
* * it's all done automatically, except the decorator, other than that we don't have to take care of it in following updates.

* it does not restore the database in any way
* documentation is not included. we should probably do this. However, thorough inline documentation and docstrings are included.

Thoughts for further improvements
* played around with inheriting the decorator to child classes. This turned out to be a lot more error prone.
* there was talk about encrypting the json. This is not included because I don't understand the purpose or the benefit.
* now that we are adding more methods to the classes, prefixing private methods with `_` becomes a bigger issue.

Fixes #490

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [X] Test Script (please provide)

```python
from embedchain import OpenSourceApp as App
from embedchain.config import OpenSourceAppConfig as AppConfig

config = AppConfig(log_level="WARNING", id="My very unique id")
app = App(config=config)
s = app.serialize()
new_app = App.deserialize(s)
print(new_app.config.id)
```

this is done better in the unit tests.


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
