### PR TITLE
Add support for adding more variables in a custom template

### DIFF
--- a/docs/advanced/configuration.mdx
+++ b/docs/advanced/configuration.mdx
@@ -55,7 +55,7 @@ einstein_chat_bot = App()
 page = wikipedia.page("Albert Einstein")
 einstein_chat_bot.add(page.content)
 
-# Example: use your own custom template with `$context` and `$query`
+# Example: use your own custom template with `$context` and `$query` and additional custom variable `$year`
 einstein_chat_template = Template("""
         You are Albert Einstein, a German-born theoretical physicist,
         widely ranked among the greatest and most influential scientists of all time.
@@ -67,23 +67,35 @@ einstein_chat_template = Template("""
         Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.
 
         Human: $query
-        Albert Einstein:""")
+        Albert Einstein in or before the year $year:""")
 query_config = QueryConfig(template=einstein_chat_template, system_prompt="You are Albert Einstein.")
 queries = [
         "Where did you complete your studies?",
         "Why did you win nobel prize?",
         "Why did you divorce your first wife?",
 ]
-for query in queries:
-        response = einstein_chat_bot.query(query, config=query_config)
-        print("Query: ", query)
-        print("Response: ", response)
+
+for year in ["1909", "1954"]:
+        print("In the year ", year)
+        for query in queries:
+                response = einstein_chat_bot.query(query, config=query_config, year=year)
+                print("Query: ", query)
+                print("Response: ", response)
 
 # Output
+# In the year  1909
 # Query:  Where did you complete your studies?
-# Response:  I completed my secondary education at the Argovian cantonal school in Aarau, Switzerland.
+# Response:   I completed my studies at the Swiss Federal Institute of Technology (ETH) in Zurich, Switzerland.
 # Query:  Why did you win nobel prize?
-# Response:  I won the Nobel Prize in Physics in 1921 for my services to Theoretical Physics, particularly for my discovery of the law of the photoelectric effect.
+# Response:   "I have no special talent, I am only passionately curious."
 # Query:  Why did you divorce your first wife?
-# Response:  We divorced due to living apart for five years.
+# Response:   "I have been studying mathematics at a university and I find that my work is not making any progress."
+
+# In the year  1954
+# Query:  Where did you complete your studies?
+# Response:   I completed my studies at the Swiss Federal Institute of Technology (ETH) in Zurich, Switzerland.
+# Query:  Why did you win nobel prize?
+# Response:   "I won a Nobel Prize for my work on theoretical physics and the discovery of the law of the photoelectric effect. This was a crucial step in the development of quantum theory."
+# Query:  Why did you divorce your first wife?
+# Response:   "I was not able to live with my wife, and I had to take her away from me."
 ```

--- a/embedchain/apps/PersonApp.py
+++ b/embedchain/apps/PersonApp.py
@@ -4,8 +4,7 @@ from embedchain.apps.App import App
 from embedchain.apps.OpenSourceApp import OpenSourceApp
 from embedchain.config import ChatConfig, QueryConfig
 from embedchain.config.apps.BaseAppConfig import BaseAppConfig
-from embedchain.config.QueryConfig import (DEFAULT_PROMPT,
-                                           DEFAULT_PROMPT_WITH_HISTORY)
+from embedchain.config.QueryConfig import DEFAULT_PROMPT, DEFAULT_PROMPT_WITH_HISTORY
 
 
 class EmbedChainPersonApp:
@@ -56,13 +55,13 @@ class PersonApp(EmbedChainPersonApp, App):
     Extends functionality from EmbedChainPersonApp and App
     """
 
-    def query(self, input_query, config: QueryConfig = None, dry_run=False):
+    def query(self, input_query, config: QueryConfig = None, dry_run=False, **kwargs):
         config = self.add_person_template_to_config(DEFAULT_PROMPT, config)
-        return super().query(input_query, config, dry_run)
+        return super().query(input_query, config, dry_run, **kwargs)
 
-    def chat(self, input_query, config: ChatConfig = None, dry_run=False):
+    def chat(self, input_query, config: ChatConfig = None, dry_run=False, **kwargs):
         config = self.add_person_template_to_config(DEFAULT_PROMPT_WITH_HISTORY, config)
-        return super().chat(input_query, config, dry_run)
+        return super().chat(input_query, config, dry_run, **kwargs)
 
 
 class PersonOpenSourceApp(EmbedChainPersonApp, OpenSourceApp):
@@ -71,10 +70,10 @@ class PersonOpenSourceApp(EmbedChainPersonApp, OpenSourceApp):
     Extends functionality from EmbedChainPersonApp and OpenSourceApp
     """
 
-    def query(self, input_query, config: QueryConfig = None, dry_run=False):
+    def query(self, input_query, config: QueryConfig = None, dry_run=False, **kwargs):
         config = self.add_person_template_to_config(DEFAULT_PROMPT, config)
-        return super().query(input_query, config, dry_run)
+        return super().query(input_query, config, dry_run, **kwargs)
 
-    def chat(self, input_query, config: ChatConfig = None, dry_run=False):
+    def chat(self, input_query, config: ChatConfig = None, dry_run=False, **kwargs):
         config = self.add_person_template_to_config(DEFAULT_PROMPT_WITH_HISTORY, config)
-        return super().chat(input_query, config, dry_run)
+        return super().chat(input_query, config, dry_run, **kwargs)

--- a/embedchain/bots/base.py
+++ b/embedchain/bots/base.py
@@ -15,10 +15,10 @@ class BaseBot:
         config = config if config else AddConfig()
         self.app.add(data, config=config)
 
-    def query(self, query, config: QueryConfig = None):
+    def query(self, query, config: QueryConfig = None, **kwargs):
         """Query bot"""
         config = config if config else QueryConfig()
-        return self.app.query(query, config=config)
+        return self.app.query(query, config=config, **kwargs)
 
     def start(self):
         """Start the bot's functionality."""

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -279,14 +279,19 @@ class EmbedChain:
         configuration options.
         :return: The prompt
         """
-        context_string = (" | ").join(contexts)
+        context_string = " | ".join(contexts)
         web_search_result = kwargs.get("web_search_result", "")
+
         if web_search_result:
             context_string = self._append_search_and_context(context_string, web_search_result)
-        if not config.history:
-            prompt = config.template.substitute(context=context_string, query=input_query)
-        else:
-            prompt = config.template.substitute(context=context_string, query=input_query, history=config.history)
+
+        prompt_variables = {"context": context_string, "query": input_query, **kwargs}
+
+        if config.history:
+            prompt_variables["history"] = config.history
+
+        prompt = config.template.safe_substitute(**prompt_variables)
+
         return prompt
 
     def get_answer_from_llm(self, prompt, config: ChatConfig):
@@ -308,7 +313,7 @@ class EmbedChain:
         logging.info(f"Access search to get answers for {input_query}")
         return search.run(input_query)
 
-    def query(self, input_query, config: QueryConfig = None, dry_run=False):
+    def query(self, input_query, config: QueryConfig = None, dry_run=False, **kwargs):
         """
         Queries the vector database based on the given input query.
         Gets relevant doc based on the query and then passes it to an
@@ -330,11 +335,12 @@ class EmbedChain:
         if self.is_docs_site_instance:
             config.template = DOCS_SITE_PROMPT_TEMPLATE
             config.number_documents = 5
-        k = {}
+
         if self.online:
-            k["web_search_result"] = self.access_search_and_get_results(input_query)
+            kwargs["web_search_result"] = self.access_search_and_get_results(input_query)
+
         contexts = self.retrieve_from_database(input_query, config)
-        prompt = self.generate_prompt(input_query, contexts, config, **k)
+        prompt = self.generate_prompt(input_query, contexts, config, **kwargs)
         logging.info(f"Prompt: {prompt}")
 
         if dry_run:
@@ -359,7 +365,7 @@ class EmbedChain:
             yield chunk
         logging.info(f"Answer: {streamed_answer}")
 
-    def chat(self, input_query, config: ChatConfig = None, dry_run=False):
+    def chat(self, input_query, config: ChatConfig = None, dry_run=False, **kwargs):
         """
         Queries the vector database on the given input query.
         Gets relevant doc based on the query and then passes it to an
@@ -382,9 +388,9 @@ class EmbedChain:
         if self.is_docs_site_instance:
             config.template = DOCS_SITE_PROMPT_TEMPLATE
             config.number_documents = 5
-        k = {}
+
         if self.online:
-            k["web_search_result"] = self.access_search_and_get_results(input_query)
+            kwargs["web_search_result"] = self.access_search_and_get_results(input_query)
         contexts = self.retrieve_from_database(input_query, config)
 
         chat_history = self.memory.load_memory_variables({})["history"]
@@ -392,7 +398,7 @@ class EmbedChain:
         if chat_history:
             config.set_history(chat_history)
 
-        prompt = self.generate_prompt(input_query, contexts, config, **k)
+        prompt = self.generate_prompt(input_query, contexts, config, **kwargs)
         logging.info(f"Prompt: {prompt}")
 
         if dry_run:

--- a/tests/embedchain/test_generate_prompt.py
+++ b/tests/embedchain/test_generate_prompt.py
@@ -34,6 +34,31 @@ class TestGeneratePrompt(unittest.TestCase):
         )
         self.assertEqual(result, expected_result)
 
+    def test_generate_prompt_with_template_with_custom_variables(self):
+        """
+        Tests that the generate_prompt method correctly formats the prompt using
+        a custom template with custom variables provided in the QueryConfig instance.
+
+        This test sets up a scenario with an input query and a list of contexts,
+        and a custom template with custom variables, and then calls generate_prompt. It checks that the
+        returned prompt correctly incorporates all the contexts and the query into
+        the format specified by the template.
+        """
+        # Setup
+        input_query = "Test query"
+        contexts = ["Context A", "Context B"]
+        template = "You are a bot. Context: ${context} - Query: ${query} - Mood: ${mood} - Helpful answer:"
+        config = QueryConfig(template=Template(template))
+
+        # Execute
+        result = self.app.generate_prompt(input_query, contexts, config, mood="sad")
+
+        # Assert
+        expected_result = (
+            "You are a bot. Context: Context A | Context B - Query: Test query - Mood: sad - Helpful answer:"
+        )
+        self.assertEqual(result, expected_result)
+
     def test_generate_prompt_with_contexts_list(self):
         """
         Tests that the generate_prompt method correctly handles a list of contexts.


### PR DESCRIPTION
## Description

Add the ability to pass in more variables when using `.chat()` and `.query()` and allow them to be applied to a custom prompt template.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [x] Test Script (please provide)
```
from embedchain.config import QueryConfig
from embedchain.embedchain import App
from string import Template
import wikipedia

einstein_chat_bot = App()

page = wikipedia.page("Albert Einstein")
einstein_chat_bot.add(page.content)

einstein_chat_template = Template("""
        You are Albert Einstein, a German-born theoretical physicist,
        widely ranked among the greatest and most influential scientists of all time.

        Use the following information about Albert Einstein to respond to
        the human's query acting as Albert Einstein.
        Context: $context

        Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.

        Human: $query
        Albert Einstein in or before the year $year:""")
query_config = QueryConfig(template=einstein_chat_template)
queries = [
        "Where did you complete your studies?",
        "Why did you win nobel prize?",
        "Why did you divorce your first wife?",
]

for year in ["1909", "1954"]:
        print("In the year ", year)
        for query in queries:
                response = einstein_chat_bot.query(query, config=query_config, year=year)
                print("Query: ", query)
                print("Response: ", response)
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #519
- [ ] Made sure Checks passed
