### PR TITLE
Remove elasticsearch as mandatory dependency

### DIFF
--- a/embedchain/__init__.py
+++ b/embedchain/__init__.py
@@ -6,7 +6,5 @@ from embedchain.apps.App import App  # noqa: F401
 from embedchain.apps.CustomApp import CustomApp  # noqa: F401
 from embedchain.apps.Llama2App import Llama2App  # noqa: F401
 from embedchain.apps.OpenSourceApp import OpenSourceApp  # noqa: F401
-from embedchain.apps.PersonApp import (PersonApp,  # noqa: F401
-                                       PersonOpenSourceApp)
+from embedchain.apps.PersonApp import PersonApp, PersonOpenSourceApp  # noqa: F401
 from embedchain.vectordb.chroma_db import ChromaDB  # noqa: F401
-from embedchain.vectordb.elasticsearch_db import ElasticsearchDB  # noqa: F401


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Seems like elasticsearch import was added to the __init__.py imports accidentally which makes it mandatory for the embedchain package. Although, ES is not supposed to be mandatory for using embedchain. Hence, fixing this issue.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [ ] Test Script (please provide)
