### PR TITLE
fix: serialize non serializable

### DIFF
--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -76,6 +76,5 @@ class TestJsonSerializable(unittest.TestCase):
         # Template
         config = BaseLlmConfig(template=Template("My custom template with $query, $context and $history."))
         s = config.serialize()
-        print(s)
         new_config: BaseLlmConfig = BaseLlmConfig.deserialize(s)
         self.assertEqual(config.template.template, new_config.template.template)

--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -1,8 +1,9 @@
 import random
 import unittest
+from string import Template
 
 from embedchain import App
-from embedchain.config import AppConfig
+from embedchain.config import AppConfig, BaseLlmConfig
 from embedchain.helper.json_serializable import (JSONSerializable,
                                                  register_deserializable)
 
@@ -69,3 +70,12 @@ class TestJsonSerializable(unittest.TestCase):
         self.assertEqual(random_id, new_app.config.id)
         # We have proven that a nested class (app.config) can be serialized and deserialized just the same.
         # TODO: test deeper recursion
+
+    def test_special_subclasses(self):
+        """Test special subclasses that are not serializable by default."""
+        # Template
+        config = BaseLlmConfig(template=Template("My custom template with $query, $context and $history."))
+        s = config.serialize()
+        print(s)
+        new_config: BaseLlmConfig = BaseLlmConfig.deserialize(s)
+        self.assertEqual(config.template.template, new_config.template.template)


### PR DESCRIPTION
## Description

adds a convention with `{__type__: ..., data: ...}` to include custom serializers for attributes, which are non-serializable by default.

One example of this is `template`, which was not serializable before this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
