### PR TITLE
Fix/use template from temp llm config

### DIFF
--- a/tests/helper_classes/test_json_serializable.py
+++ b/tests/helper_classes/test_json_serializable.py
@@ -1,8 +1,9 @@
 import random
 import unittest
+from string import Template
 
 from embedchain import App
-from embedchain.config import AppConfig
+from embedchain.config import AppConfig, BaseLlmConfig
 from embedchain.helper.json_serializable import (JSONSerializable,
                                                  register_deserializable)
 
@@ -69,3 +70,12 @@ class TestJsonSerializable(unittest.TestCase):
         self.assertEqual(random_id, new_app.config.id)
         # We have proven that a nested class (app.config) can be serialized and deserialized just the same.
         # TODO: test deeper recursion
+
+    def test_special_subclasses(self):
+        """Test special subclasses that are not serializable by default."""
+        # Template
+        config = BaseLlmConfig(template=Template("My custom template with $query, $context and $history."))
+        s = config.serialize()
+        print(s)
+        new_config: BaseLlmConfig = BaseLlmConfig.deserialize(s)
+        self.assertEqual(config.template.template, new_config.template.template)


### PR DESCRIPTION
## Description

**This depends on #589 so please merge that first**

As described in the doc strings, `LlmConfig` can be assigned to `app.llm.config` for persistency. Alternatively, it can be provided as an argument to `query` or `chat` to be used for once function call only.

The problem with that was that the temporary assignment didn't always work as intended and some methods still used the actual `app.llm.config`.

With this change, the previous config is saved through serialization, then the temporary config is dropped in as a complete attribute replacement, getting assigned to `app.llm.config`. Finally, after the method has generated an answer the pervious config is deserialized.

This should be the safest way to assign the temp config, and it shouldn't be possible for any part of the code to ignore the temp config now.

If the method fails, for whatever reason, there's a `try-finally` block that should still restore the previous config.

If no custom config is used, none of this applies (no serialization or deserialization - no loss in speed).

The same logic could be used in `retrieve_from_database`, but we haven't encountered any issues there.

Fixes #584 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [X] Test Script (please provide)

```python
from string import Template

from embedchain import App
from embedchain.config import LlmConfig

einstein_chat_bot = App()

einstein_chat_template = Template(
    """
        You are Albert Einstein, a German-born theoretical physicist,
        widely ranked among the greatest and most influential scientists of all time.

        Use the following information about Albert Einstein to respond to
        the human's query acting as Albert Einstein.
        Context: $context

        Keep the response brief. If you don't know the answer, just say that you don't know, don't try to make up an answer.

        Human: $query
        Albert Einstein:"""
)


llm_config = LlmConfig(template=einstein_chat_template, system_prompt="You are Albert Einstein.")
query = "Where did you complete your studies?"
response = einstein_chat_bot.query(query, config=llm_config, dry_run=True)
print(response)
response = einstein_chat_bot.query(query, dry_run=True)
print(response)
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
