### PR TITLE
refactor: use llama hub instead of llama index

### DIFF
--- a/embedchain/loaders/notion.py
+++ b/embedchain/loaders/notion.py
@@ -2,7 +2,7 @@ import logging
 import os
 
 try:
-    from llama_index import download_loader
+    from llama_hub.notion.base import NotionPageReader
 except ImportError:
     raise ImportError(
         "Notion requires extra dependencies. Install with `pip install --upgrade embedchain[community]`"
@@ -18,8 +18,6 @@ from embedchain.utils import clean_string
 class NotionLoader(BaseLoader):
     def load_data(self, source):
         """Load data from a PDF file."""
-
-        NotionPageReader = download_loader("NotionPageReader")
 
         # Reformat Id to match notion expectation
         id = source[-32:]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ youtube-transcript-api = "^0.6.1"
 beautifulsoup4 = "^4.12.2"
 pypdf = "^3.11.0"
 pytube = "^15.0.0"
-llama-index = { version = "^0.7.21", optional = true }
+llama-hub = { version = "^0.0.29", optional = true }
 sentence-transformers = { version = "^2.2.2", optional = true }
 torch = { version = ">=2.0.0, !=2.0.1", optional = true }
 # Torch 2.0.1 is not compatible with poetry (https://github.com/pytorch/pytorch/issues/100974)
@@ -118,7 +118,7 @@ isort = "^5.12.0"
 
 [tool.poetry.extras]
 streamlit = ["streamlit"]
-community = ["llama-index"]
+community = ["llama-hub"]
 opensource = ["sentence-transformers", "torch", "gpt4all"]
 elasticsearch = ["elasticsearch"]
 poe = ["fastapi-poe"]


### PR DESCRIPTION
## Description

Use llama hub instead of llama index.

Currently, only Notion is using this in main, so I couldn't run wide compatibility tests.

My notion test actually fails, but after the import. That might be because I just reused my old test code, someone who really uses notion should test this.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [X] Test Script (please provide)

```python3
import os

from embedchain import App
from embedchain.config import AppConfig

config = AppConfig(log_level="DEBUG")
app = App(config=config)
os.environ["NOTION_INTEGRATION_TOKEN"] = "secret"

id = "test-cfbc134ca6464fc980d0391613959196"
app.add("notion", "cfbc134ca6464fc980d0391613959196")
app.add("notion", "my-page-cfbc134ca6464fc980d0391613959196")
app.add("notion", "https://www.notion.so/my-page-cfbc134ca6464fc980d0391613959196")
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
