### PR TITLE
fix: llama2 - use config with specific defaults

### DIFF
--- a/embedchain/llm/llama2.py
+++ b/embedchain/llm/llama2.py
@@ -13,6 +13,19 @@ class Llama2Llm(BaseLlm):
     def __init__(self, config: Optional[BaseLlmConfig] = None):
         if "REPLICATE_API_TOKEN" not in os.environ:
             raise ValueError("Please set the REPLICATE_API_TOKEN environment variable.")
+
+        # Set default config values specific to this llm
+        if not config:
+            config = BaseLlmConfig()
+            # Add variables to this block that have a default value in the parent class
+            config.max_tokens = 500
+            config.temperature = 0.75
+        # Add variables that are `none` by default to this block.
+        if not config.model:
+            config.model = (
+                "a16z-infra/llama13b-v2-chat:df7690f1994d94e96ad9d568eac121aecf50684a0b0963b25a41cc40061269e5"
+            )
+
         super().__init__(config=config)
 
     def get_llm_model_answer(self, prompt):
@@ -20,7 +33,11 @@ class Llama2Llm(BaseLlm):
         if self.config.system_prompt:
             raise ValueError("Llama2App does not support `system_prompt`")
         llm = Replicate(
-            model="a16z-infra/llama13b-v2-chat:df7690f1994d94e96ad9d568eac121aecf50684a0b0963b25a41cc40061269e5",
-            input={"temperature": self.config.temperature or 0.75, "max_length": 500, "top_p": self.config.top_p},
+            model=self.config.model,
+            input={
+                "temperature": self.config.temperature,
+                "max_length": self.config.max_tokens,
+                "top_p": self.config.top_p,
+            },
         )
         return llm(prompt)


### PR DESCRIPTION
## Description

* makes specific defaults for llama2 easier to maintain
* improves serialization
* fixes issue where `max_tokens` are not loaded from config

the only concern: `max_tokens` is now being used in place of `max_length`, when one is actually referring to tokens and the other might be refering to something else (not sure).

Fixes #593

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
