### PR TITLE
Fix/chat

### DIFF
--- a/embedchain/llm/base.py
+++ b/embedchain/llm/base.py
@@ -204,7 +204,7 @@ class BaseLlm(JSONSerializable):
         finally:
             if config:
                 # Restore previous config
-                self.config: BaseLlmConfig = BaseLlmConfig.deserialize(prev_config)      
+                self.config: BaseLlmConfig = BaseLlmConfig.deserialize(prev_config)
 
     def chat(self, input_query: str, contexts: List[str], config: BaseLlmConfig = None, dry_run=False):
         """


### PR DESCRIPTION
## Description

fixes an issue where chat would not work if the template contained history, but LLM instance had no history yet.

**Unit tests should be added for all scenarios that I edited in this PR!**

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [X] Unit Test
- [X] Test Script (please provide)
```python
from string import Template

from embedchain import App
from embedchain.config import LlmConfig, ChromaDbConfig

app = App(chromadb_config=ChromaDbConfig(chroma_settings={"allow_reset": True}))
app.db.reset()
app.add("lorem ipsum")
custom_template_for_chat_endpoint = Template(
    """
    You are an AI assistant for the open source library Embedchain. The docs is located at https://docs.embedchain.ai.
    Query: $query
    ==========
    Context: $context
    ==========
    Chat History: $history
    ==========
    Answer in Markdown:
"""
)
llm_config_query = LlmConfig(template=custom_template_for_chat_endpoint)
user_input = "What did I say before?"
answer = app.chat(user_input, config=llm_config_query, dry_run=False)
print(answer)

answer = app.chat(user_input, config=llm_config_query, dry_run=True)
print(answer)

answer = app.chat("please list all previous messages in bullet points", config=llm_config_query, dry_run=False)
print(answer)
```
results
```
2023-09-13 08:57:47,630 [embedchain] [INFO] Swapped std-lib sqlite3 with pysqlite3 for ChromaDb compatibility. Your original version was 3.31.1.
2023-09-13 08:57:48,776 [chromadb.telemetry.posthog] [ERROR] Failed to send telemetry event client_start: module 'chromadb' has no attribute 'get_settings'
2023-09-13 08:57:49,308 [root] [WARNING] DEPRECATION WARNING: Please use `app.db.count()` instead of `app.count()`.
2023-09-13 08:57:49,677 [chromadb.telemetry.posthog] [ERROR] Failed to send telemetry event collection_add: module 'chromadb' has no attribute 'get_settings'
2023-09-13 08:57:49,677 [root] [WARNING] DEPRECATION WARNING: Please use `app.db.count()` instead of `app.count()`.
Successfully saved lorem ipsum (DataType.TEXT). New chunks count: 1
You said "What did I say before?"

    You are an AI assistant for the open source library Embedchain. The docs is located at https://docs.embedchain.ai.
    Query: What did I say before?
    ==========
    Context: lorem ipsum
    ==========
    Chat History: Human: What did I say before?
AI: You said "What did I say before?"
    ==========
    Answer in Markdown:

- Human: What did I say before?
- AI: You said "What did I say before?"
```


## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
