### PR TITLE
Fixed minor grammatical issues in documentation: Interface Types

### DIFF
--- a/docs/advanced/interface_types.mdx
+++ b/docs/advanced/interface_types.mdx
@@ -36,7 +36,7 @@ print(naval_chat_bot.chat("what did the author say about happiness?"))
 
 #### Dry Run
 
-Dry Run is an option in the `add`, `query` and `chat` methods that allows the user to displays the data chunks and their constructed prompt which is not send to the LLM, to save money. It's used for [testing](/advanced/testing#dry-run).
+Dry Run is an option in the `add`, `query` and `chat` methods that allows the user to display the data chunks and their constructed prompt which is not sent to the LLM, to save money. It's used for [testing](/advanced/testing#dry-run).
 
 
 ### Stream Response


### PR DESCRIPTION
## Fixed minor grammatical error in Interface Types page

- Changed _displays_ to _display_ and _send_ to _sent_. 