### PR TITLE
[OpenSearch] Add support for filtering docs based on app_id in opensearch db

### DIFF
--- a/embedchain/vectordb/opensearch.py
+++ b/embedchain/vectordb/opensearch.py
@@ -144,6 +144,11 @@ class OpenSearchDB(BaseVectorDB):
             http_auth=self.config.http_auth,
             use_ssl=True,
         )
+
+        pre_filter = {"match_all": {}}  # default
+        if "app_id" in where:
+            app_id = where["app_id"]
+            pre_filter = {"bool": {"must": [{"term": {"metadata.app_id": app_id}}]}}
         docs = docsearch.similarity_search(
             input_query,
             search_type="script_scoring",
@@ -151,6 +156,8 @@ class OpenSearchDB(BaseVectorDB):
             vector_field="embeddings",
             text_field="text",
             metadata_field="metadata",
+            pre_filter=pre_filter,
+            k=n_results,
         )
         contents = [doc.page_content for doc in docs]
         return contents

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.0.62"
+version = "0.0.63"
 description = "embedchain is a framework to easily create LLM powered bots over any dataset"
 authors = ["Taranjeet Singh"]
 license = "Apache License"


### PR DESCRIPTION
## Description

Currently OpenSearch db doesn't support metadata filering based on the app_id. This PR adds support for the same.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Tested via the script given below:

```python
from embedchain import CustomApp
from embedchain.config import OpenSearchDBConfig, CustomAppConfig
from embedchain.embedder.openai import OpenAIEmbedder
from embedchain.vectordb.opensearch import OpenSearchDB
from embedchain.llm.openai import OpenAILlm

opensearch_url = "https://localhost:9200"
http_auth = ("username", "passsword")

db_config = OpenSearchDBConfig(
    opensearch_url=opensearch_url,
    http_auth=http_auth,
    use_ssl=True,
    timeout=30,
)

app_config = CustomAppConfig(id="new_app_id_1")
db = OpenSearchDB(config=db_config)

# App1: Mark Zuck app
app1 = CustomApp(config=app_config, llm=OpenAILlm(), embedder=OpenAIEmbedder(), db=db)
app1.add("https://en.wikipedia.org/wiki/Mark_Zuckerberg")
app1.add("https://www.forbes.com/profile/mark-zuckerberg/")
print(app1.query("What is the net worth of Mark?"))

# App2: Elon Musk app
app2 = CustomApp(config=app_config, llm=OpenAILlm(), embedder=OpenAIEmbedder(), db=db)
app2.add("https://en.wikipedia.org/wiki/Elon_Musk")
app2.add("https://www.forbes.com/profile/elon-musk")
app2.add("https://www.britannica.com/biography/Elon-Musk")
print(app2.query("What is the net worth of Elon?"))


# Test if the two apps are using the same set of documents for getting context
print(app2.query("Who is richer? Elon or Mark?"))

#### Output 

```python
Index 'embedchain_store' already exists.
Successfully saved https://en.wikipedia.org/wiki/Mark_Zuckerberg (DataType.WEB_PAGE). New chunks count: 0
Successfully saved https://www.forbes.com/profile/mark-zuckerberg/ (DataType.WEB_PAGE). New chunks count: 0
The net worth of Mark Zuckerberg is $106.6 billion.
Index 'embedchain_store' already exists.
Successfully saved https://en.wikipedia.org/wiki/Elon_Musk (DataType.WEB_PAGE). New chunks count: 362
Successfully saved https://www.forbes.com/profile/elon-musk (DataType.WEB_PAGE). New chunks count: 14
Successfully saved https://www.britannica.com/biography/Elon-Musk (DataType.WEB_PAGE). New chunks count: 28
The net worth of Elon Musk is $252.6 billion.

Based on the given context, it is not possible to determine who is richer between Elon and Mark. The context only mentions the wealth rankings of Jeff Bezos and Elon Musk, but there is no mention of Mark's wealth.
```