### PR TITLE
Modify URL assignment based on data type - Fix adding qna_pair when "where" fails check due to wrong source

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -351,6 +351,12 @@ class EmbedChain(JSONSerializable):
 
         # get existing ids, and discard doc if any common id exist.
         where = {"url": src}
+        # If necessary override the "url" value, otherwise `where` will fail validation checks,
+        # due to the wrong type.
+        if chunker.data_type.value in [item.value for item in SpecialDataType]:
+            # Handle "url" differently, because "src" is a tuple in the case of a QNA_PAIR
+            if chunker.data_type == DataType.QNA_PAIR:
+                where = {"url": src[0]}
         if self.config.id is not None:
             where["app_id"] = self.config.id
 

--- a/tests/embedchain/test_add.py
+++ b/tests/embedchain/test_add.py
@@ -36,6 +36,26 @@ class TestApp(unittest.TestCase):
         self.assertEqual(self.app.user_asks, [["https://www.google.com/sitemap.xml", "sitemap", {"meta": "meta-data"}]])
 
     @patch("chromadb.api.models.Collection.Collection.add", MagicMock)
+    def test_add_qna_pair(self):
+        """
+        In addition to the test_add function, this test checks that qna_pairs can be added with the correct data type.
+        """
+        self.app.add(
+            ("Who is Naval Ravikant?", "Naval Ravikant is an Indian-American entrepreneur and investor."),
+            metadata={"meta": "meta-data"},
+        )
+        self.assertEqual(
+            self.app.user_asks,
+            [
+                [
+                    ("Who is Naval Ravikant?", "Naval Ravikant is an Indian-American entrepreneur and investor."),
+                    "qna_pair",
+                    {"meta": "meta-data"},
+                ]
+            ],
+        )
+
+    @patch("chromadb.api.models.Collection.Collection.add", MagicMock)
     def test_add_forced_type(self):
         """
         Test that you can also force a data_type with `add`.


### PR DESCRIPTION


## Description

Refactored the code that decides how URL is assigned to handle the special case when the data type is included in the SpecialDataType enumeration. Ensuring appropriate handling of such special data types allows significant flexibility and accuracy when dealing with a variety of data types.

Fixes #611

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tried to add a `qna_pair`.

```
app.add(("Hi", "How are you?"))
app.add(source=("Hi", "How are you?"), data_type="qna_pair")
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [X] Made sure Checks passed
