### PR TITLE
[Bugfix]: Fix issue of context overspilling into other apps

### DIFF
--- a/embedchain/chunkers/base_chunker.py
+++ b/embedchain/chunkers/base_chunker.py
@@ -44,6 +44,7 @@ class BaseChunker(JSONSerializable):
 
             for chunk in chunks:
                 chunk_id = hashlib.sha256((chunk + url).encode()).hexdigest()
+                chunk_id = f"{app_id}--{chunk_id}" if app_id is not None else chunk_id
                 if idMap.get(chunk_id) is None:
                     idMap[chunk_id] = True
                     chunk_ids.append(chunk_id)

--- a/tests/chunkers/test_base_chunker.py
+++ b/tests/chunkers/test_base_chunker.py
@@ -44,8 +44,8 @@ def test_create_chunks(chunker, text_splitter_mock, loader_mock, app_id, data_ty
 
     result = chunker.create_chunks(loader_mock, "test_src", app_id)
     expected_ids = [
-        hashlib.sha256(("Chunk 1" + "URL 1").encode()).hexdigest(),
-        hashlib.sha256(("Chunk 2" + "URL 1").encode()).hexdigest(),
+        f"{app_id}--" + hashlib.sha256(("Chunk 1" + "URL 1").encode()).hexdigest(),
+        f"{app_id}--" + hashlib.sha256(("Chunk 2" + "URL 1").encode()).hexdigest(),
     ]
 
     assert result["documents"] == ["Chunk 1", "Chunk 2"]


### PR DESCRIPTION
## Description

Noticed that there is a minor issue where if you create multiple apps in embedchain but add same data source, it will not try to add data source for the second app since it assumes that it exists. But this behaviour is not correct. We only want to not add data for an app if the data has not been added before for that app only.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
