### PR TITLE
[Docs] Add back sitemap loader docstring

### DIFF
--- a/embedchain/loaders/sitemap.py
+++ b/embedchain/loaders/sitemap.py
@@ -20,6 +20,12 @@ from embedchain.utils import is_readable
 
 @register_deserializable
 class SitemapLoader(BaseLoader):
+    """
+    This method takes a sitemap URL as input and retrieves
+    all the URLs to use the WebPageLoader to load content
+    of each page.
+    """
+
     def load_data(self, sitemap_url):
         output = []
         web_page_loader = WebPageLoader()


### PR DESCRIPTION
## Description

Accidentally removed the docstring in the last commit. Adding it back for sitemap loader.

## Type of change

- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
