### PR TITLE
[Bug fix] Update sleep time for substack loader and version bump

### DIFF
--- a/embedchain/loaders/substack.py
+++ b/embedchain/loaders/substack.py
@@ -81,6 +81,6 @@ class SubstackLoader(BaseLoader):
             if data:
                 output.append({"content": data, "meta_data": {"url": link}})
             # TODO: allow users to configure this
-            time.sleep(0.4)  # added to avoid rate limiting
+            time.sleep(1.0)  # added to avoid rate limiting
 
         return {"doc_id": doc_id, "data": output}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.14"
+version = "0.1.15"
 description = "Data platform for LLMs - Load, index, retrieve and sync any unstructured data"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",


### PR DESCRIPTION
## Description

Seems like sleep time of 0.4 secs was throwing 429 from substack. Hence bumping to 1 sec for now.
