### PR TITLE
Update SQLITE_PATH

### DIFF
--- a/embedchain/constants.py
+++ b/embedchain/constants.py
@@ -3,6 +3,6 @@ from pathlib import Path
 
 ABS_PATH = os.getcwd()
 HOME_DIR = str(Path.home())
-CONFIG_DIR = os.path.join(HOME_DIR, ".embedchain")
+CONFIG_DIR = os.path.join(ABS_PATH, "db/.embedchain")
 CONFIG_FILE = os.path.join(CONFIG_DIR, "config.json")
 SQLITE_PATH = os.path.join(CONFIG_DIR, "embedchain.db")


### PR DESCRIPTION
Changed the SQLITE_PATH to be based out of CWD/db for easier development

## Description

The SQLITE_PATH was initially based out of the Home directory. So after deleting the Vector DB for any reason, the app couldn't be retrained with the same files as the hashes were being stored in the Home_DIR/.embedchain. So deleting it becomes difficult. Putting it in the db folder of the Current Working Directory makes it easier to manage during development

Fixes #981 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #XXXX (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
