### PR TITLE
added option to load dict config

### DIFF
--- a/embedchain/apps/app.py
+++ b/embedchain/apps/app.py
@@ -126,7 +126,19 @@ class App(EmbedChain):
         """
         with open(yaml_path, "r") as file:
             config_data = yaml.safe_load(file)
+        return cls.from_dict_config(config_data)
 
+    @classmethod
+    def from_dict_config(cls, config_data_dict: dict):
+        """
+        Instantiate an App object from a dictionary configuration.
+
+        :param config_data_dict: dictionary configuration.
+        :type config_data_dict: dict
+        :return: An instance of the App class.
+        :rtype: App
+        """
+        config_data = config_data_dict
         app_config_data = config_data.get("app", {})
         llm_config_data = config_data.get("llm", {})
         db_config_data = config_data.get("vectordb", {})


### PR DESCRIPTION
## Description

This pull request introduces a feature that enables configuration loading directly from a Python dictionary, augmenting flexibility within the EmbedChain setup process. The essential configuration can be defined by the user in a YAML file, and multiple bots can be configured with slight modifications to the main configuration without the need to create multiple YAML files. If users require differing configurations, such as varied templates, system_prompts, or temperature, they can load the main YAML file and then apply changes to the dictionary before creating an EmbedChain instance. This enhancement simplifies the configuration management and aligns with EmbedChain's commitment to providing efficiency and ease of use for users working with multiple bots.
