### PR TITLE
Fix multiple top level packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.31"
+version = "0.1.32"
 description = "Data platform for LLMs - Load, index, retrieve and sync any unstructured data"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",
@@ -13,10 +13,13 @@ exclude = [
     "configs",
     "notebooks"
 ]
+packages = [
+    { include = "embedchain" },
+]
 
 [build-system]
-requires = ["setuptools", "wheel"]
-build-backend = "setuptools.build_meta"
+build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core"]
 
 [tool.ruff]
 select = ["E", "F"]


### PR DESCRIPTION
## Description

Used poetry's core to manage package build instead of setuptools so that we can add,

```toml
packages = [
    { include = "embedchain" },
] # to build and install embedchain package only
```

Fixes #759 