### PR TITLE
Fix the Error Caused by Executing Repo.clone_from Twice

### DIFF
--- a/embedchain/loaders/github.py
+++ b/embedchain/loaders/github.py
@@ -85,7 +85,6 @@ class GithubLoader(BaseLoader):
                 logging.info("Fetch completed.")
             else:
                 logging.info("Cloning repository...")
-                Repo.clone_from(repo_url, local_path)
                 repo = Repo.clone_from(repo_url, local_path)
                 logging.info("Clone completed.")
             return repo.head.commit.tree


### PR DESCRIPTION
## Description
In github.py, Repo.clone_from(repo_url, local_path) is used twice, causing an error when executed the second time.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [ ] Test Script (please provide)