### PR TITLE
[chore] docs update: don't need open ai key for gpt4all model

### DIFF
--- a/docs/get-started/faq.mdx
+++ b/docs/get-started/faq.mdx
@@ -90,10 +90,7 @@ llm:
 <CodeGroup>
 
 ```python main.py
-import os
 from embedchain import Pipeline as App
-
-os.environ['OPENAI_API_KEY'] = 'xxx'
 
 # load llm configuration from opensource.yaml file
 app = App.from_config(config_path="opensource.yaml")


### PR DESCRIPTION
## Description

Removed open ai key statements from our faq
