### PR TITLE
[chore] Remove `deployment_name` for openai embedder and update docs

### DIFF
--- a/docs/examples/notebooks-and-replits.mdx
+++ b/docs/examples/notebooks-and-replits.mdx
@@ -1,5 +1,5 @@
 ---
-title: 🔎 Examples
+title: Notebooks & Replits
 ---
 
 # Explore awesome apps

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -136,6 +136,7 @@
     {
       "group": "Examples",
       "pages": [
+        "examples/notebooks-and-replits",
         {
           "group": "REST API Service",
           "pages": [

--- a/notebooks/openai.ipynb
+++ b/notebooks/openai.ipynb
@@ -90,7 +90,6 @@
         "  provider: openai\n",
         "  config:\n",
         "    model: text-embedding-ada-002\n",
-        "    deployment_name: ec_embeddings_ada_002\n",
         "\"\"\"\n",
         "\n",
         "# Write the multi-line string to a YAML file\n",


### PR DESCRIPTION
## Description

- Added `Notebooks & Replits` page
- removed `deployment_name` from openai google colab notebook