### PR TITLE
[chore] pypdf and bs4 by default in package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ clean:
 lint:
 	poetry run ruff .
 
+# for example: make test file=tests/test_factory.py
 test:
 	poetry run pytest $(file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.36"
+version = "0.1.37"
 description = "Data platform for LLMs - Load, index, retrieve and sync any unstructured data"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",
@@ -99,10 +99,10 @@ openai = ">=1.1.1"
 chromadb = "^0.4.17"
 posthog = "^3.0.2"
 rich = "^13.7.0"
+beautifulsoup4 = "^4.12.2"
+pypdf = "^3.11.0"
 tiktoken = { version = "^0.4.0", optional = true }
 youtube-transcript-api = { version = "^0.6.1", optional = true }
-beautifulsoup4 = { version = "^4.12.2", optional = true }
-pypdf = { version = "^3.11.0", optional = true }
 pytube = { version = "^15.0.0", optional = true }
 duckduckgo-search = { version = "^3.8.5", optional = true }
 llama-hub = { version = "^0.0.43", optional = true }
@@ -179,10 +179,8 @@ cohere = ["cohere"]
 milvus = ["pymilvus"]
 dataloaders=[
     "youtube-transcript-api",
-    "beautifulsoup4",
     "docx2txt",
     "duckduckgo-search",
-    "pypdf",
     "pytube",
     "sentence-transformers",
     "unstructured",


### PR DESCRIPTION
## Description

- Keep `pypdf` and `bs4` in package by default as they are the most used ones (remove friction)

cc @deshraj 