### PR TITLE
Fix: indents in yaml file

### DIFF
--- a/docs/integration/streamlit-mistral.mdx
+++ b/docs/integration/streamlit-mistral.mdx
@@ -85,22 +85,22 @@ pip install embedchain streamlit
     <Tab title="config.yaml">
     ```yaml
     app:
-    config:
-        name: 'mistral-streamlit-app'
+        config:
+            name: 'mistral-streamlit-app'
 
     llm:
-    provider: huggingface
-    config:
-        model: 'mistralai/Mixtral-8x7B-Instruct-v0.1'
-        temperature: 0.1
-        max_tokens: 250
-        top_p: 0.1
-        stream: true
+        provider: huggingface
+        config:
+            model: 'mistralai/Mixtral-8x7B-Instruct-v0.1'
+            temperature: 0.1
+            max_tokens: 250
+            top_p: 0.1
+            stream: true
 
     embedder:
-    provider: huggingface
-    config:
-        model: 'sentence-transformers/all-mpnet-base-v2'
+        provider: huggingface
+        config:
+            model: 'sentence-transformers/all-mpnet-base-v2'
     ```
     </Tab>
 </Tabs>


### PR DESCRIPTION
The config.yaml example was not parsable and throwing cryptic errors like

```
  File "/Users/dhravyashah/Documents/code/raspAI/env/lib/python3.9/site-packages/embedchain/pipeline.py", line 395, in from_config
    raise Exception(f"Error occurred while validating the config. Error: {str(e)}")
Exception: Error occurred while validating the config. Error: Key 'app' error:
None should be instance of 'dict'
```

Adding indents solves this issue

## Description

Added indents in documentation

Fixes # (no issue)

## Type of change

Please delete options that are not relevant.
- [x] Documentation update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist
- [ ] Made sure Checks passed
