### PR TITLE
fix: typo when import helpers.json_serializable on rss_feed files

### DIFF
--- a/embedchain/chunkers/rss_feed.py
+++ b/embedchain/chunkers/rss_feed.py
@@ -4,7 +4,7 @@ from langchain.text_splitter import RecursiveCharacterTextSplitter
 
 from embedchain.chunkers.base_chunker import BaseChunker
 from embedchain.config.add_config import ChunkerConfig
-from embedchain.helper.json_serializable import register_deserializable
+from embedchain.helpers.json_serializable import register_deserializable
 
 
 @register_deserializable

--- a/embedchain/loaders/rss_feed.py
+++ b/embedchain/loaders/rss_feed.py
@@ -1,6 +1,6 @@
 import hashlib
 
-from embedchain.helper.json_serializable import register_deserializable
+from embedchain.helpers.json_serializable import register_deserializable
 from embedchain.loaders.base_loader import BaseLoader
 
 


### PR DESCRIPTION
## Description

When I tried to used the rss_feed loader, I encoutered errors. The errors were 2 typos when importing the method register_deserializable from json_serializable file.

```sh
from  => embedchain.helper.json_serializable import register_deserializable

to    => embedchain.helpers.json_serializable import register_deserializable
```

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

I tested it manually after fixing the typos.
No tests files were made for the rss_feed feature.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
