### PR TITLE
[Improvement] fix slack loader max_count

### DIFF
--- a/embedchain/loaders/slack.py
+++ b/embedchain/loaders/slack.py
@@ -73,7 +73,7 @@ class SlackLoader(BaseLoader):
                 query=query,
                 sort="timestamp",
                 sort_dir="desc",
-                count=1000,
+                count=100,
             )
 
             messages = results.get("messages")

--- a/embedchain/loaders/slack.py
+++ b/embedchain/loaders/slack.py
@@ -16,10 +16,10 @@ class SlackLoader(BaseLoader):
     def __init__(self, config: Optional[Dict[str, Any]] = None):
         super().__init__()
 
-        if config is not None:
-            self.config = config
-        else:
-            self.config = {"base_url": SLACK_API_BASE_URL}
+        self.config = config if config else {}
+
+        if "base_url" not in self.config:
+            self.config["base_url"] = SLACK_API_BASE_URL
 
         self.client = None
         self._setup_loader(self.config)
@@ -73,7 +73,7 @@ class SlackLoader(BaseLoader):
                 query=query,
                 sort="timestamp",
                 sort_dir="desc",
-                count=100,
+                count=self.config.get("count", 100),
             )
 
             messages = results.get("messages")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.54"
+version = "0.1.55"
 description = "Data platform for LLMs - Load, index, retrieve and sync any unstructured data"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",


### PR DESCRIPTION
## Description

This PR improves the slack loader to fetch maximum possible matching messages when searching using slack API. Max supported count is `100`, otherwise defaults to `20`.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [ ] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
