### PR TITLE
Fix: Missing package requirement

### DIFF
--- a/docs/get-started/quickstart.mdx
+++ b/docs/get-started/quickstart.mdx
@@ -10,6 +10,10 @@ First install the python package.
 ```bash
 pip install embedchain
 ```
+**Note**: If you're using colab, you'd probably need to install this:
+```
+pip install -U sentence-transformers #==2.2.2 # current working version
+```
 
 Once you have installed the package, depending upon your preference you can either use:
 


### PR DESCRIPTION
Fixes # Missing `sentence-transformers` when using colab.

## Type of change
- [ X] Bug fix (non-breaking change which fixes an issue)
- [X ] Documentation update
