### PR TITLE
[Bugfix] fix chat history management when app.reset

### DIFF
--- a/docs/api-reference/pipeline/delete.mdx
+++ b/docs/api-reference/pipeline/delete.mdx
@@ -2,7 +2,7 @@
 title: 🗑 delete
 ---
 
-`delete_chat_history()` method allows you to delete all previous messages in a chat history.
+`delete_session_chat_history()` method allows you to delete all previous messages in a chat history.
 
 ## Usage
 
@@ -15,5 +15,5 @@ app.add("https://www.forbes.com/profile/elon-musk")
 
 app.chat("What is the net worth of Elon Musk?")
 
-app.delete_chat_history()
+app.delete_session_chat_history()
 ```

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -663,13 +663,17 @@ class EmbedChain(JSONSerializable):
         self.db.reset()
         self.cursor.execute("DELETE FROM data_sources WHERE pipeline_id = ?", (self.config.id,))
         self.connection.commit()
-        self.delete_chat_history()
+        self.delete_all_chat_history(app_id=self.config.id)
         # Send anonymous telemetry
         self.telemetry.capture(event_name="reset", properties=self._telemetry_props)
 
     def get_history(self, num_rounds: int = 10, display_format: bool = True):
         return self.llm.memory.get(app_id=self.config.id, num_rounds=num_rounds, display_format=display_format)
 
-    def delete_chat_history(self, session_id: str = "default"):
+    def delete_session_chat_history(self, session_id: str = "default"):
         self.llm.memory.delete(app_id=self.config.id, session_id=session_id)
         self.llm.update_history(app_id=self.config.id)
+
+    def delete_all_chat_history(self, app_id: str):
+        self.llm.memory.delete(app_id=app_id)
+        self.llm.update_history(app_id=app_id)

--- a/embedchain/memory/base.py
+++ b/embedchain/memory/base.py
@@ -53,7 +53,7 @@ class ChatHistory:
         logging.info(f"Added chat memory to db with id: {memory_id}")
         return memory_id
 
-    def delete(self, app_id: str, session_id: str):
+    def delete(self, app_id: str, session_id: Optional[str] = None):
         """
         Delete all chat history for a given app_id and session_id.
         This is useful for deleting chat history for a given user.
@@ -63,8 +63,14 @@ class ChatHistory:
 
         :return: None
         """
-        DELETE_CHAT_HISTORY_QUERY = "DELETE FROM ec_chat_history WHERE app_id=? AND session_id=?"
-        self.cursor.execute(DELETE_CHAT_HISTORY_QUERY, (app_id, session_id))
+        if session_id:
+            DELETE_CHAT_HISTORY_QUERY = "DELETE FROM ec_chat_history WHERE app_id=? AND session_id=?"
+            params = (app_id, session_id)
+        else:
+            DELETE_CHAT_HISTORY_QUERY = "DELETE FROM ec_chat_history WHERE app_id=?"
+            params = (app_id,)
+
+        self.cursor.execute(DELETE_CHAT_HISTORY_QUERY, params)
         self.connection.commit()
 
     def get(self, app_id, session_id, num_rounds=10, display_format=False) -> list[ChatMessage]:

--- a/embedchain/memory/base.py
+++ b/embedchain/memory/base.py
@@ -105,7 +105,7 @@ class ChatHistory:
                 history.append(memory)
         return history
 
-    def count(self, app_id: str, session_id: str):
+    def count(self, app_id: str, session_id: Optional[str] = None):
         """
         Count the number of chat messages for a given app_id and session_id.
 
@@ -114,8 +114,14 @@ class ChatHistory:
 
         :return: The number of chat messages for a given app_id and session_id
         """
-        QUERY = "SELECT COUNT(*) FROM ec_chat_history WHERE app_id=? AND session_id=?"
-        self.cursor.execute(QUERY, (app_id, session_id))
+        if session_id:
+            QUERY = "SELECT COUNT(*) FROM ec_chat_history WHERE app_id=? AND session_id=?"
+            params = (app_id, session_id)
+        else:
+            QUERY = "SELECT COUNT(*) FROM ec_chat_history WHERE app_id=?"
+            params = (app_id,)
+
+        self.cursor.execute(QUERY, params)
         count = self.cursor.fetchone()[0]
         return count
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.61"
+version = "0.1.62"
 description = "Data platform for LLMs - Load, index, retrieve and sync any unstructured data"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",

--- a/tests/memory/test_chat_memory.py
+++ b/tests/memory/test_chat_memory.py
@@ -59,9 +59,26 @@ def test_delete_chat_history(chat_memory_instance):
 
         chat_memory_instance.add(app_id, session_id, chat_message)
 
+    session_id_2 = "test_session_2"
+
+    for i in range(1, 6):
+        human_message = f"Question {i}"
+        ai_message = f"Answer {i}"
+
+        chat_message = ChatMessage()
+        chat_message.add_user_message(human_message)
+        chat_message.add_ai_message(ai_message)
+
+        chat_memory_instance.add(app_id, session_id_2, chat_message)
+
     chat_memory_instance.delete(app_id, session_id)
 
     assert chat_memory_instance.count(app_id, session_id) == 0
+    assert chat_memory_instance.count(app_id) == 5
+
+    chat_memory_instance.delete(app_id)
+
+    assert chat_memory_instance.count(app_id) == 0
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description

This PR fixes chat history management when calling `app.reset()`.
- instead of only deleting `default` session, delete all sessions at the time of `app.reset`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test
- [ ] Test Script (please provide)

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
