### PR TITLE
Fix #1176 (a bug in the chromadb provider definition example)

### DIFF
--- a/notebooks/chromadb.ipynb
+++ b/notebooks/chromadb.ipynb
@@ -72,13 +72,15 @@
       "outputs": [],
       "source": [
         "app = App.from_config(config={\n",
-        "    \"provider\": \"chroma\",\n",
-        "    \"config\": {\n",
-        "        \"collection_name\": \"my-collection\",\n",
-        "        \"host\": \"your-chromadb-url.com\",\n",
-        "        \"port\": 5200,\n",
-        "        \"allow_reset\": True\n",
-        "    }\n",
+        "     \"vectordb\": {\n",
+        "        \"provider\": \"chroma\",\n",
+        "        \"config\": {\n",
+        "            \"collection_name\": \"my-collection\",\n",
+        "            \"host\": \"your-chromadb-url.com\",\n",
+        "            \"port\": 5200,\n",
+        "            \"allow_reset\": True\n",
+        "        }\n",
+        "     }\n",
         "})"
       ]
     },


### PR DESCRIPTION
## Description

This fixes issue #1176 (a bug in the chromadb provider definition, inside `notebooks/chromadb.ipynb`)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

