### PR TITLE
[Bugfix] fix llm chat with using session_id as args for referring history

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -620,7 +620,7 @@ class EmbedChain(JSONSerializable):
             )
         else:
             answer = self.llm.chat(
-                input_query=input_query, contexts=contexts_data_for_llm_query, config=config, dry_run=dry_run
+                input_query=input_query, contexts=contexts_data_for_llm_query, config=config, dry_run=dry_run, session_id=session_id
             )
 
         # add conversation in memory


### PR DESCRIPTION
## Description

fix llm chat with using session_id as args for referring history

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
