### PR TITLE
[Bug Fix] Fix issue of loading other languages in csv file

### DIFF
--- a/embedchain/loaders/csv.py
+++ b/embedchain/loaders/csv.py
@@ -27,9 +27,9 @@ class CsvLoader(BaseLoader):
             return StringIO(response.text)
         elif url.scheme == "file":
             path = url.path
-            return open(path, newline="")  # Open the file using the path from the URI
+            return open(path, newline="", encoding="utf-8")  # Open the file using the path from the URI
         else:
-            return open(content, newline="")  # Treat content as a regular file path
+            return open(content, newline="", encoding="utf-8")  # Treat content as a regular file path
 
     @staticmethod
     def load_data(content):


### PR DESCRIPTION
## Description

An error occurred in the process of loading csv written in Korean, so the reading method was fixed.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Converted read process to utf-8 and loaded csv file

Example csv
```csv
이름,전화번호
테스트,010-1234-5678
```

Test Source
```py
import os
from embedchain import App
from dotenv import load_dotenv

load_dotenv()
openai_api_key = os.getenv('OPENAI_API_KEY')

app = App()
app.add('/path/to/file.csv', data_type='csv')  # type: ignore
app.query("테스트 전화번호")
```

- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
