### PR TITLE
Update URL Validation Regex to Support IP Addresses and Port Numbers

### DIFF
--- a/embedchain/loaders/json.py
+++ b/embedchain/loaders/json.py
@@ -36,8 +36,7 @@ class JSONReader:
         return ["\n".join(useful_lines)]
 
 
-VALID_URL_PATTERN = "^https:\/\/[0-9A-Za-z]+(\.[0-9A-Za-z]+)*\/[0-9A-Za-z_\/]*\.json$"
-
+VALID_URL_PATTERN = "^https?://(?:www\.)?(?:\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}|[a-zA-Z0-9.-]+)(?::\d+)?/(?:[^/\s]+/)*[^/\s]+\.json$"
 
 class JSONLoader(BaseLoader):
     @staticmethod


### PR DESCRIPTION
## Description

This pull request updates the URL validation regex to accommodate URLs with http or https protocols, IP addresses, optional port numbers, and URL-encoded characters, ensuring broader validation coverage. This change allows the system to correctly validate URLs like http://192.168.1.140:9000/1%202%20Inflación-wav.json, which include direct IP access with port specifications and encoded characters, enhancing compatibility with a wider range of URLs.

Fixes #1232 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
