### PR TITLE
[Bug Fix] Add support for `AWS_REGION` override

### DIFF
--- a/docs/components/llms.mdx
+++ b/docs/components/llms.mdx
@@ -666,7 +666,8 @@ embedder:
 
 ### Setup
 - Before using the AWS Bedrock LLM, make sure you have the appropriate model access from [Bedrock Console](https://us-east-1.console.aws.amazon.com/bedrock/home?region=us-east-1#/modelaccess).
-- You will also need `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` to authenticate the API with AWS. You can find these in your [AWS Console](https://us-east-1.console.aws.amazon.com/iam/home?region=us-east-1#/users).
+- You will also need to authenticate the `boto3` client by using a method in the [AWS documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#configuring-credentials)
+- You can optionally export an `AWS_REGION`
 
 
 ### Usage
@@ -679,6 +680,7 @@ from embedchain import App
 
 os.environ["AWS_ACCESS_KEY_ID"] = "xxx"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "xxx"
+os.environ["AWS_REGION"] = "us-west-2"
 
 app = App.from_config(config_path="config.yaml")
 ```

--- a/embedchain/llm/aws_bedrock.py
+++ b/embedchain/llm/aws_bedrock.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 from langchain.llms import Bedrock
@@ -25,7 +26,7 @@ class AWSBedrockLlm(BaseLlm):
                 'Please install with `pip install --upgrade "embedchain[aws-bedrock]"`'
             ) from None
 
-        self.boto_client = boto3.client("bedrock-runtime", "us-west-2")
+        self.boto_client = boto3.client("bedrock-runtime", "us-west-2" or os.environ.get("AWS_REGION"))
 
         kwargs = {
             "model_id": config.model or "amazon.titan-text-express-v1",


### PR DESCRIPTION
## Description

When I used the AWS Bedrock LLM configuration in my [article](https://how.wtf/how-to-use-embedchain-with-aws-bedrock.html), I got a model access error because the region is hardcoded to `us-west-2` in the source.

`AWS_REGION` is a [widely-accepted environment variable](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html) for AWS credentials.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation update

## How Has This Been Tested?

- [X] Test Script (please provide)

I ran the following script:

```python
from embedchain import App

bot = App.from_config(config_path="config.yaml")

bot.add("https://en.wikipedia.org/wiki/Ada_Lovelace")

print(bot.query("Who is Ada Lovelace?"))
```

with my `AWS_REGION` environment variable exported and an AWS profile set.

Here is the configuration:

```yaml
llm:
  provider: aws_bedrock
  config:
    model: anthropic.claude-v2
    model_kwargs:
      temperature: 0.5
      top_p: 1
      top_k: 250
      max_tokens_to_sample: 200
```

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
