### PR TITLE
Fixes to null data results and openAI embedding limits

### DIFF
--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -429,15 +429,33 @@ class EmbedChain(JSONSerializable):
 
         if dry_run:
             return list(documents), metadatas, ids, 0
-
+        
         # Count before, to calculate a delta in the end.
         chunks_before_addition = self.db.count()
 
-        self.db.add(documents=documents, metadatas=metadatas, ids=ids, **kwargs)
-        count_new_chunks = self.db.count() - chunks_before_addition
+        
+        # Filter out empty documents and ensure they meet the API requirements
+        valid_documents = [doc for doc in documents if doc and isinstance(doc, str)]
 
+        documents = valid_documents
+
+        # Chunk documents into batches of 2048 and handle each batch
+        # helps wigth large loads of embeddings  that hit OpenAI limits
+        document_batches = [documents[i:i+2048] for i in range(0, len(documents), 2048)]
+        for batch in document_batches:
+            try:
+                # Add only valid batches
+                if batch:
+                    self.db.add(documents=batch, metadatas=metadatas, ids=ids, **kwargs)
+            except BadRequestError as e:
+                print(f"Failed to add batch due to a bad request: {e}")
+                # Handle the error, e.g., by logging, retrying, or skipping
+
+        count_new_chunks = self.db.count() - chunks_before_addition
         print(f"Successfully saved {src} ({chunker.data_type}). New chunks count: {count_new_chunks}")
+        
         return list(documents), metadatas, ids, count_new_chunks
+
 
     @staticmethod
     def _format_result(results):
@@ -473,7 +491,9 @@ class EmbedChain(JSONSerializable):
         :return: List of contents of the document that matched your query
         :rtype: list[str]
         """
+        print("Query passed in config:", config)
         query_config = config or self.llm.config
+        print("Final config:", query_config)
         if where is not None:
             where = where
         else:
@@ -484,6 +504,7 @@ class EmbedChain(JSONSerializable):
             if self.config.id is not None:
                 where.update({"app_id": self.config.id})
 
+        print('Number documents', query_config)
         contexts = self.db.query(
             input_query=input_query,
             n_results=query_config.number_documents,

--- a/embedchain/embedchain.py
+++ b/embedchain/embedchain.py
@@ -447,9 +447,11 @@ class EmbedChain(JSONSerializable):
                 # Add only valid batches
                 if batch:
                     self.db.add(documents=batch, metadatas=metadatas, ids=ids, **kwargs)
-            except BadRequestError as e:
+            except Exception as e:
                 print(f"Failed to add batch due to a bad request: {e}")
                 # Handle the error, e.g., by logging, retrying, or skipping
+                pass
+
 
         count_new_chunks = self.db.count() - chunks_before_addition
         print(f"Successfully saved {src} ({chunker.data_type}). New chunks count: {count_new_chunks}")

--- a/embedchain/vectordb/weaviate.py
+++ b/embedchain/vectordb/weaviate.py
@@ -274,6 +274,9 @@ class WeaviateDB(BaseVectorDB):
                 .do()
             )
 
+        if results["data"]["Get"].get(self.index_name) is None:
+            return []
+
         docs = results["data"]["Get"].get(self.index_name)
         contexts = []
         for doc in docs:


### PR DESCRIPTION
## Description

I was trying to load in a large sitemap and hit a 403 from OpenAI.  Turns out that there are limitations on the embeddings endpoints:

- The input parameter may not take a list longer than 2048 elements (chunks of text).
- The total number of tokens across all list elements of the input parameter cannot exceed 1,000,000. (Because the rate limit is 1,000,000 tokens per minute.)
- Each individual array element (chunk of text) cannot be more than 8191 tokens.

Discussion can be found here: https://github.com/openai/openai-python/issues/519#issuecomment-1636921388

This fixes the first  limit breaking the documents in batches of 2048 elements in the array being sent.

There is also a small fix here for issues that occur when the weaviate provider doesn't retrieve any results.

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] Documentation update

## How Has This Been Tested?

I was trying to load this sitemap:

https://zonos.com/sitemap.xml

It will break under current non-batching implementation against the OpenAI API.  Fix runs it cleanly and it works.  General usage and operations so far have been running fine with the change.

Please delete options that are not relevant.


## Checklist:

- [ ] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x ] New and existing unit tests pass locally with my changes
- [x ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
