### PR TITLE
Typo fixed in youtube-channel.mdx

### DIFF
--- a/docs/components/data-sources/youtube-channel.mdx
+++ b/docs/components/data-sources/youtube-channel.mdx
@@ -7,7 +7,7 @@ title: '📽️ Youtube Channel'
 Make sure you have all the required packages installed before using this data type. You can install them by running the following command in your terminal.
 
 ```bash
-pip install -u "embedchain[youtube]"
+pip install -U "embedchain[youtube]"
 ```
 
 ## Usage


### PR DESCRIPTION

## Description
Hey there! Noticed a small typo in the pip install command. The -u flag should actually be -U for upgrading. Just fixing it up to avoid any confusion for fellow users. 😊

## Type of change

-  [x] Documentation update




