### PR TITLE
Typo fixed youtube-video.mdx

### DIFF
--- a/docs/components/data-sources/youtube-video.mdx
+++ b/docs/components/data-sources/youtube-video.mdx
@@ -7,7 +7,7 @@ title: '📺 Youtube Video'
 Make sure you have all the required packages installed before using this data type. You can install them by running the following command in your terminal.
 
 ```bash
-pip install -u "embedchain[youtube]"
+pip install -U "embedchain[youtube]"
 ```
 
 ## Usage


### PR DESCRIPTION
`pip install -u "embedchain[youtube]"` command. The `-u` flag should be `-U` for upgrading.

## Description

 Noticed a small typo in the `pip install` command. The `-u` flag should actually be `-U` for upgrading. Just fixing it up to avoid any 
 confusion for fellow users. 😊

- [x] Documentation update


