### PR TITLE
[Bug fix] Fix issue for using any metadata db apart from sqlite

### DIFF
--- a/embedchain/core/db/database.py
+++ b/embedchain/core/db/database.py
@@ -19,7 +19,12 @@ class DatabaseManager:
 
     def setup_engine(self) -> None:
         """Initializes the database engine and session factory."""
-        self.engine = create_engine(self.database_uri, echo=self.echo, connect_args={"check_same_thread": False})
+        if not self.database_uri:
+            raise RuntimeError("Database URI is not set. Set the EMBEDCHAIN_DB_URI environment variable.")
+        connect_args = {}
+        if self.database_uri.startswith("sqlite"):
+            connect_args["check_same_thread"] = False
+        self.engine = create_engine(self.database_uri, echo=self.echo, connect_args=connect_args)
         self._session_factory = scoped_session(sessionmaker(bind=self.engine))
         Base.metadata.bind = self.engine
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "embedchain"
-version = "0.1.84"
+version = "0.1.85"
 description = "Simplest open source retrieval(RAG) framework"
 authors = [
     "Taranjeet Singh <taranjeet@embedchain.ai>",


### PR DESCRIPTION
## Description

Forgot to remove the sqlite specific args when making connection for the metadata sql database. Fixed the issue in this PR.

Now, users can try any sql database as their metadata database which stores the chat history and data sources added to their apps.

### Example

1. Start postgres db using following command using docker: 

```bash
docker run --name some-postgres -e POSTGRES_PASSWORD=mysecretpassword -p 5432:5432 -d postgres
```

2. Now, run embedchain app that uses the created database and stores information there:

```python
import os
from embedchain import App

os.environ["EMBEDCHAIN_DB_URI"] = "postgresql://postgres:mysecretpassword@localhost:5432/postgres"
app = App()
app.add("https://www.forbes.com/profile/elon-musk")
answer = app.chat("What is the net worth of Elon Musk?")
print(answer)
```

3. Once done, you can check the data by going into psql console and see the data:

```bash
$ docker exec -it some-postgres psql -U postgres

postgres=# \d
 public | alembic_version | table | postgres
 public | ec_chat_history | table | postgres
 public | ec_data_sources | table | postgres

postgres=# \d ec_chat_history
 app_id     | character varying           |           | not null |
 id         | character varying           |           | not null |
 session_id | character varying           |           | not null |
 question   | text                        |           |          |
 answer     | text                        |           |          |
 metadata   | text                        |           |          |
 created_at | timestamp without time zone |           |          |
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
