### PR TITLE
Feature: Custom Ollama endpoint base_url

### DIFF
--- a/configs/ollama.yaml
+++ b/configs/ollama.yaml
@@ -5,6 +5,7 @@ llm:
     temperature: 0.5
     top_p: 1
     stream: true
+    base_url: http://localhost:11434
 
 embedder:
   provider: huggingface

--- a/embedchain/config/llm/base.py
+++ b/embedchain/config/llm/base.py
@@ -96,6 +96,7 @@ class BaseLlmConfig(BaseConfig):
         endpoint: Optional[str] = None,
         model_kwargs: Optional[dict[str, Any]] = None,
         local: Optional[bool] = False,
+        base_url: Optional[str] = None,
     ):
         """
         Initializes a configuration class instance for the LLM.
@@ -169,6 +170,7 @@ class BaseLlmConfig(BaseConfig):
         self.endpoint = endpoint
         self.model_kwargs = model_kwargs
         self.local = local
+        self.base_url = base_url
 
         if isinstance(prompt, str):
             prompt = Template(prompt)

--- a/embedchain/llm/ollama.py
+++ b/embedchain/llm/ollama.py
@@ -31,6 +31,7 @@ class OllamaLlm(BaseLlm):
             temperature=config.temperature,
             top_p=config.top_p,
             callback_manager=CallbackManager(callback_manager),
+            base_url=config.base_url,
         )
 
         return llm.invoke(prompt)

--- a/embedchain/utils/misc.py
+++ b/embedchain/utils/misc.py
@@ -427,6 +427,7 @@ def validate_config(config_data):
                     Optional("endpoint"): str,
                     Optional("model_kwargs"): dict,
                     Optional("local"): bool,
+                    Optional("base_url"): str,
                 },
             },
             Optional("vectordb"): {


### PR DESCRIPTION
## Description

Langchain includes Ollama's base_url for localhost on the default port 11434, but in our case it runs on a different server than Embedchain. We needed to allow customization of this address, so we changed the necessary files to include the custom address to the YAML configuration file.

Fixes # (issue)

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)

## How Has This Been Tested?

Create a Ollama server and point the YAML config value "base_url" to the server.

- [ ] Unit Test

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My changes generate no new warnings
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] Made sure Checks passed
