### PR TITLE
added missing provider for 'vllm'

### DIFF
--- a/embedchain/factory.py
+++ b/embedchain/factory.py
@@ -25,6 +25,7 @@ class LlmFactory:
         "mistralai": "embedchain.llm.mistralai.MistralAILlm",
         "groq": "embedchain.llm.groq.GroqLlm",
         "nvidia": "embedchain.llm.nvidia.NvidiaLlm",
+        "vllm": "embedchain.llm.vllm.VLLM",
     }
     provider_to_config_class = {
         "embedchain": "embedchain.config.llm.base.BaseLlmConfig",


### PR DESCRIPTION
## Description

To support custom or locally hosted Mistral model (or any other) through a VLLM server, the provider type 'vllm' was missing from the list of supported providers in factory.py.

Fixes # (issue)

## Type of change

- [y] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested the change using the embedchain-admin fullstack app.

## Checklist:

- [y] My code follows the style guidelines of this project
- [y] I have performed a self-review of my own code
- [y] My changes generate no new warnings
- [y] I have checked my code and corrected any misspellings