### PR TITLE
Added http clients in config

### DIFF
--- a/embedchain/config/llm/base.py
+++ b/embedchain/config/llm/base.py
@@ -98,6 +98,8 @@ class BaseLlmConfig(BaseConfig):
         base_url: Optional[str] = None,
         endpoint: Optional[str] = None,
         model_kwargs: Optional[dict[str, Any]] = None,
+        http_client: Optional[Any] = None,
+        http_async_client: Optional[Any] = None,
         local: Optional[bool] = False,
     ):
         """
@@ -172,6 +174,8 @@ class BaseLlmConfig(BaseConfig):
         self.base_url = base_url
         self.endpoint = endpoint
         self.model_kwargs = model_kwargs
+        self.http_client = http_client
+        self.http_async_client = http_async_client
         self.local = local
 
         if isinstance(prompt, str):

--- a/embedchain/llm/openai.py
+++ b/embedchain/llm/openai.py
@@ -50,6 +50,8 @@ class OpenAILlm(BaseLlm):
                 callbacks=callbacks,
                 api_key=api_key,
                 base_url=base_url,
+                http_client=config.http_client,
+                http_async_client=config.http_async_client,
             )
         else:
             chat = ChatOpenAI(**kwargs, api_key=api_key, base_url=base_url)


### PR DESCRIPTION
## Description

embedchain's OpenAI LLM class does not allow the user to provide a custom http client. This can be done through the langchain's ChatOpenAI class which embedchain uses but does not expose the relevant arguments to change the http client. This PR exposes the`http_client` parameter into the config thereby allowing the user to change it.

Fixes #1357 

## Type of change
New feature (non-breaking change which adds functionality)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
