### PR TITLE
Allow ollama llm to take custom callback for handling streaming

### DIFF
--- a/embedchain/llm/ollama.py
+++ b/embedchain/llm/ollama.py
@@ -23,7 +23,12 @@ class OllamaLlm(BaseLlm):
 
     @staticmethod
     def _get_answer(prompt: str, config: BaseLlmConfig) -> Union[str, Iterable]:
-        callback_manager = [StreamingStdOutCallbackHandler()] if config.stream else [StdOutCallbackHandler()]
+        if config.stream:
+            callbacks = config.callbacks if config.callbacks else [StreamingStdOutCallbackHandler()]
+        else:
+            callbacks = [StdOutCallbackHandler()]
+
+        callback_manager = CallbackManager(callbacks)
 
         llm = Ollama(
             model=config.model,

--- a/embedchain/llm/ollama.py
+++ b/embedchain/llm/ollama.py
@@ -28,14 +28,12 @@ class OllamaLlm(BaseLlm):
         else:
             callbacks = [StdOutCallbackHandler()]
 
-        callback_manager = CallbackManager(callbacks)
-
         llm = Ollama(
             model=config.model,
             system=config.system_prompt,
             temperature=config.temperature,
             top_p=config.top_p,
-            callback_manager=CallbackManager(callback_manager),
+            callback_manager=CallbackManager(callbacks),
             base_url=config.base_url,
         )
 

--- a/tests/llm/test_ollama.py
+++ b/tests/llm/test_ollama.py
@@ -2,6 +2,7 @@ import pytest
 
 from embedchain.config import BaseLlmConfig
 from embedchain.llm.ollama import OllamaLlm
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 
 
 @pytest.fixture
@@ -29,3 +30,20 @@ def test_get_answer_mocked_ollama(ollama_llm_config, mocker):
     answer = llm.get_llm_model_answer(prompt)
 
     assert answer == "Mocked answer"
+
+
+def test_get_llm_model_answer_with_streaming(ollama_llm_config, mocker):
+    ollama_llm_config.stream = True
+    ollama_llm_config.callbacks = [StreamingStdOutCallbackHandler()]
+    mocked_ollama_chat = mocker.patch("embedchain.llm.ollama.OllamaLlm._get_answer", return_value="Test answer")
+
+    llm = OllamaLlm(ollama_llm_config)
+    llm.get_llm_model_answer("Test query")
+
+    mocked_ollama_chat.assert_called_once()
+    call_args = mocked_ollama_chat.call_args
+    config_arg = call_args[1]["config"]
+    callbacks = config_arg.callbacks
+
+    assert len(callbacks) == 1
+    assert isinstance(callbacks[0], StreamingStdOutCallbackHandler)


### PR DESCRIPTION
## Description

I wanted to create an api which handles streaming responses from an ollama model, but for some reason even though I pass `stream: True` in config, it only streams the output in `stdout`. I was expecting to get a generator given the return type of the function `def _get_answer(prompt: str, config: BaseLlmConfig) -> Union[str, Iterable]`

However I noticed that there is `callback` config which can be used to create the generator from new tokens, but I noticed it is not used in all models, saw it being used in `openai` but in `ollama` we are always by default using `StreamingStdOutCallbackHandler()`.

This PR allows you to use custom callbacks even if you are using `ollama`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added a test case for this
- [x] Unit Test

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
