### PR TITLE
[Docs]: Fix the Title and Description for OpenLIT Integration

### DIFF
--- a/docs/integration/openlit.mdx
+++ b/docs/integration/openlit.mdx
@@ -1,6 +1,6 @@
 ---
-title: ':telescope: OpenLIT'
-description: 'OpenTelemetry-native LLM application observabiliy and evaluations'
+title: '🔭 OpenLIT'
+description: 'OpenTelemetry-native Observability and Evals for LLMs & GPUs'
 ---
 
 Embedchain now supports integration with [OpenLIT](https://github.com/openlit/openlit).


### PR DESCRIPTION
## Description
The title in the integration doc for OpenLIT appears to have `:telescope:` instead of 🔭  . This PR fixes the issue and also does a minor update to the description. 

Fixes # (issue)
NA

## Type of change

Please delete options that are not relevant.

- [x] Documentation update

## How Has This Been Tested?

Just title and description update

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
