### PR TITLE
Fix AzureOpenAi deprecated warning and streaming

### DIFF
--- a/embedchain/llm/azure_openai.py
+++ b/embedchain/llm/azure_openai.py
@@ -18,19 +18,28 @@ class AzureOpenAILlm(BaseLlm):
 
     @staticmethod
     def _get_answer(prompt: str, config: BaseLlmConfig) -> str:
-        from langchain_community.chat_models import AzureChatOpenAI
+        from langchain_openai import AzureChatOpenAI
 
         if not config.deployment_name:
             raise ValueError("Deployment name must be provided for Azure OpenAI")
 
-        chat = AzureChatOpenAI(
-            deployment_name=config.deployment_name,
-            openai_api_version=str(config.api_version) if config.api_version else "2023-05-15",
-            model_name=config.model or "gpt-3.5-turbo",
-            temperature=config.temperature,
-            max_tokens=config.max_tokens,
-            streaming=config.stream,
-        )
+        if config.stream:
+            callbacks = config.callbacks if config.callbacks else [StreamingStdOutCallbackHandler()]
+            chat = AzureChatOpenAI(
+                deployment_name=config.deployment_name,
+                openai_api_version=str(config.api_version) if config.api_version else "2024-02-01",
+                model_name=config.model or "gpt-3.5-turbo",
+                temperature=config.temperature,
+                max_tokens=config.max_tokens,
+                callbacks=callbacks,
+                streaming=config.stream)
+        else:
+            chat = AzureChatOpenAI(
+                deployment_name=config.deployment_name,
+                openai_api_version=str(config.api_version) if config.api_version else "2024-02-01",
+                model_name=config.model or "gpt-3.5-turbo",
+                temperature=config.temperature,
+                max_tokens=config.max_tokens)
 
         if config.top_p and config.top_p != 1:
             logger.warning("Config option `top_p` is not supported by this model.")

--- a/embedchain/llm/azure_openai.py
+++ b/embedchain/llm/azure_openai.py
@@ -1,6 +1,7 @@
 import logging
 from typing import Optional
 
+from langchain.callbacks.streaming_stdout import StreamingStdOutCallbackHandler
 from embedchain.config import BaseLlmConfig
 from embedchain.helpers.json_serializable import register_deserializable
 from embedchain.llm.base import BaseLlm


### PR DESCRIPTION
Fix AzureOpenAi streaming
Fix AzureOpenAi deprecated warning

## Description

Changed the import of AzureChatOpenAI from langchain_community.chat_models to langchain_openai
Merged code from openai.py to support streaming
Changed default api_version to newest 24-02-01

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Prior, if set streaming=True with a streaming client implementation as in embedchain/examples/chat-pdf/app.py, thread.join() will never end. Now the tokens are displayed and thread.join() will continue.

Please delete options that are not relevant.

- [ ] Test Script embedchain/examples/chat-pdf/app.py with 'llm.provider' = 'azure_openai' and available deployment_name and environment variabls AZURE_OPENAI_ENDPOINT and AZURE_OPENAI_API_KEY set.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
