### PR TITLE
Fixed Azure OpenAI Deprecations and Adjusted the Tests

### DIFF
--- a/embedchain/embedder/openai.py
+++ b/embedchain/embedder/openai.py
@@ -2,7 +2,7 @@ import os
 from typing import Optional
 
 from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
-from langchain_community.embeddings import AzureOpenAIEmbeddings
+from langchain_openai.embeddings import AzureOpenAIEmbeddings
 
 from embedchain.config import BaseEmbedderConfig
 from embedchain.embedder.base import BaseEmbedder

--- a/embedchain/llm/azure_openai.py
+++ b/embedchain/llm/azure_openai.py
@@ -14,18 +14,18 @@ class AzureOpenAILlm(BaseLlm):
         super().__init__(config=config)
 
     def get_llm_model_answer(self, prompt):
-        return AzureOpenAILlm._get_answer(prompt=prompt, config=self.config)
+        return self._get_answer(prompt=prompt, config=self.config)
 
     @staticmethod
     def _get_answer(prompt: str, config: BaseLlmConfig) -> str:
-        from langchain_community.chat_models import AzureChatOpenAI
+        from langchain_openai import AzureChatOpenAI
 
         if not config.deployment_name:
             raise ValueError("Deployment name must be provided for Azure OpenAI")
 
         chat = AzureChatOpenAI(
             deployment_name=config.deployment_name,
-            openai_api_version=str(config.api_version) if config.api_version else "2023-05-15",
+            openai_api_version=str(config.api_version) if config.api_version else "2024-02-01",
             model_name=config.model or "gpt-3.5-turbo",
             temperature=config.temperature,
             max_tokens=config.max_tokens,
@@ -37,4 +37,4 @@ class AzureOpenAILlm(BaseLlm):
 
         messages = BaseLlm._get_messages(prompt, system_prompt=config.system_prompt)
 
-        return chat(messages).content
+        return chat.invoke(messages).content

--- a/tests/llm/test_azure_openai.py
+++ b/tests/llm/test_azure_openai.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from langchain.schema import HumanMessage, SystemMessage
@@ -29,9 +29,13 @@ def test_get_llm_model_answer(azure_openai_llm):
 
 def test_get_answer(azure_openai_llm):
     with patch("langchain_openai.AzureChatOpenAI") as mock_chat:
-        prompt = "Test Prompt"
-        azure_openai_llm._get_answer(prompt, azure_openai_llm.config)
+        mock_chat_instance = mock_chat.return_value
+        mock_chat_instance.invoke.return_value = MagicMock(content="Test Response")
 
+        prompt = "Test Prompt"
+        response = azure_openai_llm._get_answer(prompt, azure_openai_llm.config)
+
+        assert response == "Test Response"
         mock_chat.assert_called_once_with(
             deployment_name=azure_openai_llm.config.deployment_name,
             openai_api_version="2024-02-01",

--- a/tests/llm/test_azure_openai.py
+++ b/tests/llm/test_azure_openai.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from langchain.schema import HumanMessage, SystemMessage
@@ -28,24 +28,17 @@ def test_get_llm_model_answer(azure_openai_llm):
 
 
 def test_get_answer(azure_openai_llm):
-    with patch("langchain_community.chat_models.AzureChatOpenAI") as mock_chat:
-        mock_chat_instance = mock_chat.return_value
-        mock_chat_instance.return_value = MagicMock(content="Test Response")
-
+    with patch("langchain_openai.AzureChatOpenAI") as mock_chat:
         prompt = "Test Prompt"
-        response = azure_openai_llm._get_answer(prompt, azure_openai_llm.config)
+        azure_openai_llm._get_answer(prompt, azure_openai_llm.config)
 
-        assert response == "Test Response"
         mock_chat.assert_called_once_with(
             deployment_name=azure_openai_llm.config.deployment_name,
-            openai_api_version="2023-05-15",
+            openai_api_version="2024-02-01",
             model_name=azure_openai_llm.config.model or "gpt-3.5-turbo",
             temperature=azure_openai_llm.config.temperature,
             max_tokens=azure_openai_llm.config.max_tokens,
             streaming=azure_openai_llm.config.stream,
-        )
-        mock_chat_instance.assert_called_once_with(
-            azure_openai_llm._get_messages(prompt, system_prompt=azure_openai_llm.config.system_prompt)
         )
 
 
@@ -65,6 +58,7 @@ def test_when_no_deployment_name_provided():
         llm = AzureOpenAILlm(config)
         llm.get_llm_model_answer("Test Prompt")
 
+
 def test_with_api_version():
     config = BaseLlmConfig(
         deployment_name="azure_deployment",
@@ -75,8 +69,7 @@ def test_with_api_version():
         api_version="2024-02-01",
     )
 
-    with patch("langchain_community.chat_models.AzureChatOpenAI") as mock_chat:
-
+    with patch("langchain_openai.AzureChatOpenAI") as mock_chat:
         llm = AzureOpenAILlm(config)
         llm.get_llm_model_answer("Test Prompt")
 


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Changed the AzureOpenAIEmbeddings import package from "langchain_community.embeddings" to "langchain_openai.embeddings"

Changed the AzureChatOpenAI import package from "langchain_community.embeddings" to "langchain_openai.embeddings"

Changed the default openai_api_version from "2023-05-15" to the newest: "2024-02-01"

Replaced chat(messages).content for chat.invoke(messages).content `BaseChatModel.__call__` is deprecated

Changed the tests for azure open ai to patch the new packages instead of the older ones

Fixes #1373 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Please delete options that are not relevant.

- [x] Unit Test

Tested using a valid AZURE_OPENAI_API_KEY, endpoint and deployment_name. The test code was the same as the one in the documentation.

https://docs.embedchain.ai/components/embedding-models#azure-openai

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [x] closes #1373  
- [x] Made sure Checks passed
