### PR TITLE
Adding model_kwargs for huggingface embedders.

### DIFF
--- a/docs/api-reference/advanced/configuration.mdx
+++ b/docs/api-reference/advanced/configuration.mdx
@@ -229,6 +229,7 @@ Alright, let's dive into what each key means in the yaml config above:
         - `deployment_name` (String): The deployment name for the embedding model.
         - `title` (String): The title for the embedding model for Google Embedder.
         - `task_type` (String): The task type for the embedding model for Google Embedder.
+        - `model_kwargs` (Dict): Used to pass extra arguments to embedders.
 5. `chunker` Section:
     - `chunk_size` (Integer): The size of each chunk of text that is sent to the language model.
     - `chunk_overlap` (Integer): The amount of overlap between each chunk of text.

--- a/docs/components/embedding-models.mdx
+++ b/docs/components/embedding-models.mdx
@@ -192,6 +192,8 @@ embedder:
   provider: huggingface
   config:
     model: 'sentence-transformers/all-mpnet-base-v2'
+    model_kwargs:
+        trust_remote_code: True # Only use if you trust your embedder
 ```
 
 </CodeGroup>

--- a/embedchain/config/embedder/base.py
+++ b/embedchain/config/embedder/base.py
@@ -30,6 +30,7 @@ class BaseEmbedderConfig:
         :type api_key: Optional[str], optional
         :param api_base: huggingface api base, defaults to None
         :type api_base: Optional[str], optional
+        :type model_kwargs: Optional[Dict[str, Any]], key-value pair defaults to None
         """
         self.model = model
         self.deployment_name = deployment_name

--- a/embedchain/config/embedder/base.py
+++ b/embedchain/config/embedder/base.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Any, Dict, Optional
 
 from embedchain.helpers.json_serializable import register_deserializable
 
@@ -13,6 +13,7 @@ class BaseEmbedderConfig:
         endpoint: Optional[str] = None,
         api_key: Optional[str] = None,
         api_base: Optional[str] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
     ):
         """
         Initialize a new instance of an embedder config class.
@@ -36,3 +37,4 @@ class BaseEmbedderConfig:
         self.endpoint = endpoint
         self.api_key = api_key
         self.api_base = api_base
+        self.model_kwargs = model_kwargs or {}

--- a/embedchain/config/embedder/base.py
+++ b/embedchain/config/embedder/base.py
@@ -30,7 +30,8 @@ class BaseEmbedderConfig:
         :type api_key: Optional[str], optional
         :param api_base: huggingface api base, defaults to None
         :type api_base: Optional[str], optional
-        :type model_kwargs: Optional[Dict[str, Any]], key-value pair defaults to None
+        :param model_kwargs: key-value arguments for the embedding model, defaults a dict inside init.
+        :type model_kwargs: Optional[Dict[str, Any]], defaults a dict inside init.
         """
         self.model = model
         self.deployment_name = deployment_name

--- a/embedchain/embedder/huggingface.py
+++ b/embedchain/embedder/huggingface.py
@@ -31,7 +31,8 @@ class HuggingFaceEmbedder(BaseEmbedder):
                 huggingfacehub_api_token=self.config.api_key or os.getenv("HUGGINGFACE_ACCESS_TOKEN"),
             )
         else:
-            embeddings = HuggingFaceEmbeddings(model_name=self.config.model)
+            embeddings = HuggingFaceEmbeddings(model_name=self.config.model, model_kwargs=self.config.model_kwargs)
+
         embedding_fn = BaseEmbedder._langchain_default_concept(embeddings)
         self.set_embedding_fn(embedding_fn=embedding_fn)
 

--- a/embedchain/utils/misc.py
+++ b/embedchain/utils/misc.py
@@ -474,6 +474,7 @@ def validate_config(config_data):
                     Optional("vector_dimension"): int,
                     Optional("base_url"): str,
                     Optional("endpoint"): str,
+                    Optional("model_kwargs"): dict,
                 },
             },
             Optional("embedding_model"): {

--- a/tests/embedder/test_huggingface.py
+++ b/tests/embedder/test_huggingface.py
@@ -1,0 +1,20 @@
+import os
+
+import pytest
+from unittest.mock import patch
+from embedchain.config import BaseEmbedderConfig
+from embedchain.embedder.huggingface import HuggingFaceEmbedder
+
+
+def test_huggingface_embedder_with_model(monkeypatch):
+    config = BaseEmbedderConfig(model="test-model", model_kwargs={"param": "value"})
+    with patch('embedchain.embedder.huggingface.HuggingFaceEmbeddings') as mock_embeddings:
+        embedder = HuggingFaceEmbedder(config=config)
+        assert embedder.config.model == "test-model"
+        assert embedder.config.model_kwargs == {"param": "value"}
+        mock_embeddings.assert_called_once_with(
+            model_name="test-model",
+            model_kwargs={"param": "value"}
+        )
+
+

--- a/tests/embedder/test_huggingface_embedder.py
+++ b/tests/embedder/test_huggingface_embedder.py
@@ -1,6 +1,4 @@
-import os
 
-import pytest
 from unittest.mock import patch
 from embedchain.config import BaseEmbedderConfig
 from embedchain.embedder.huggingface import HuggingFaceEmbedder


### PR DESCRIPTION
## Description

This change allows passing additional params huggingface embedder using `model_kwargs`. This allows the `trust_remote_code=True` option for various models not added to `huggingface/transformers`.

Fixes #1380

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

I have added unit test for `HuggingFaceEmbedder`. (first unit test for an embedder 🎉)

Also tested using, 
main.py - 
```
import os
from embedchain import App

app = App.from_config(config_path="./config.yaml")

app.add("https://en.wikipedia.org/wiki/Sun_Tzu")

while True:
    question = input("Enter question: ")
    if question in ["q", "exit", "quit"]:
        break
    answer = app.query(question)
    print(answer)
```
config.yaml - 
```
llm:
  provider: openai
  config:
    model: 'gpt-3.5-turbo'
    temperature: 0.5
    max_tokens: 1000
    top_p: 1
    stream: false

embedder:
  provider: huggingface
  config:
    model: 'nomic-ai/nomic-embed-text-v1'
    model_kwargs:
      trust_remote_code: True

```

Output - 
```
Enter question: which book did sun tuz write?
Sun Tzu is traditionally credited as the author of The Art of War, an influential work of military strategy that has affected both Western and East Asian philosophy and military thought.
```

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
