### PR TITLE
http_client and http_async_client bugfix

### DIFF
--- a/docs/api-reference/advanced/configuration.mdx
+++ b/docs/api-reference/advanced/configuration.mdx
@@ -30,6 +30,7 @@ llm:
       response_format: 
         type: json_object
     api_version: 2024-02-01
+    http_client_proxies: http://testproxy.mem0.net:8000
     prompt: |
       Use the following pieces of context to answer the query at the end.
       If you don't know the answer, just say that you don't know, don't try to make up an answer.
@@ -89,7 +90,8 @@ cache:
       "system_prompt": "Act as William Shakespeare. Answer the following questions in the style of William Shakespeare.",
       "api_key": "sk-xxx",
       "model_kwargs": {"response_format": {"type": "json_object"}},
-      "api_version": "2024-02-01"
+      "api_version": "2024-02-01",
+      "http_client_proxies": "http://testproxy.mem0.net:8000",
     }
   },
   "vectordb": {
@@ -150,7 +152,8 @@ config = {
                 "Act as William Shakespeare. Answer the following questions in the style of William Shakespeare."
             ),
             'api_key': 'sk-xxx',
-            "model_kwargs": {"response_format": {"type": "json_object"}}
+            "model_kwargs": {"response_format": {"type": "json_object"}},
+            "http_client_proxies": "http://testproxy.mem0.net:8000",
         }
     },
     'vectordb': {

--- a/docs/api-reference/advanced/configuration.mdx
+++ b/docs/api-reference/advanced/configuration.mdx
@@ -211,6 +211,8 @@ Alright, let's dive into what each key means in the yaml config above:
         - `number_documents` (Integer): Number of documents to pull from the vectordb as context, defaults to 1
         - `api_key` (String): The API key for the language model.
         - `model_kwargs` (Dict): Keyword arguments to pass to the language model. Used for `aws_bedrock` provider, since it requires different arguments for each model.
+        - `http_client_proxies` (Dict | String): The proxy server settings used to create `self.http_client` using `httpx.Client(proxies=http_client_proxies)`
+        - `http_async_client_proxies` (Dict | String): The proxy server settings for async calls used to create `self.http_async_client` using `httpx.AsyncClient(proxies=http_async_client_proxies)`
 3. `vectordb` Section:
     - `provider` (String): The provider for the vector database, set to 'chroma'. You can find the full list of vector database providers in [our docs](/components/vector-databases).
     - `config`:

--- a/embedchain/config/llm/base.py
+++ b/embedchain/config/llm/base.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from string import Template
-from typing import Any, Mapping, Optional, Dict
+from typing import Any, Mapping, Optional, Dict, Union
 
 import httpx
 
@@ -101,8 +101,8 @@ class BaseLlmConfig(BaseConfig):
         base_url: Optional[str] = None,
         endpoint: Optional[str] = None,
         model_kwargs: Optional[dict[str, Any]] = None,
-        http_client_proxies: Optional[Dict | str] = None,
-        http_async_client_proxies: Optional[Dict | str] = None,
+        http_client_proxies: Optional[Union[Dict, str]] = None,
+        http_async_client_proxies: Optional[Union[Dict, str]] = None,
         local: Optional[bool] = False,
         default_headers: Optional[Mapping[str, str]] = None,
         api_version: Optional[str] = None,

--- a/embedchain/config/llm/base.py
+++ b/embedchain/config/llm/base.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import re
 from string import Template
 from typing import Any, Mapping, Optional, Dict
@@ -7,7 +6,6 @@ from typing import Any, Mapping, Optional, Dict
 import httpx
 
 from embedchain.config.base_config import BaseConfig
-from embedchain.core.db.database import setup_engine, init_db
 from embedchain.helpers.json_serializable import register_deserializable
 
 logger = logging.getLogger(__name__)

--- a/embedchain/config/llm/base.py
+++ b/embedchain/config/llm/base.py
@@ -1,9 +1,13 @@
 import logging
+import os
 import re
 from string import Template
-from typing import Any, Mapping, Optional
+from typing import Any, Mapping, Optional, Dict
+
+import httpx
 
 from embedchain.config.base_config import BaseConfig
+from embedchain.core.db.database import setup_engine, init_db
 from embedchain.helpers.json_serializable import register_deserializable
 
 logger = logging.getLogger(__name__)
@@ -99,8 +103,8 @@ class BaseLlmConfig(BaseConfig):
         base_url: Optional[str] = None,
         endpoint: Optional[str] = None,
         model_kwargs: Optional[dict[str, Any]] = None,
-        http_client: Optional[Any] = None,
-        http_async_client: Optional[Any] = None,
+        http_client_proxies: Optional[Dict | str] = None,
+        http_async_client_proxies: Optional[Dict | str] = None,
         local: Optional[bool] = False,
         default_headers: Optional[Mapping[str, str]] = None,
         api_version: Optional[str] = None,
@@ -149,6 +153,11 @@ class BaseLlmConfig(BaseConfig):
         :type callbacks: Optional[list], optional
         :param query_type: The type of query to use, defaults to None
         :type query_type: Optional[str], optional
+        :param http_client_proxies: The proxy server settings used to create self.http_client, defaults to None
+        :type http_client_proxies: Optional[Dict | str], optional
+        :param http_async_client_proxies: The proxy server settings for async calls used to create
+        self.http_async_client, defaults to None
+        :type http_async_client_proxies: Optional[Dict | str], optional
         :param local: If True, the model will be run locally, defaults to False (for huggingface provider)
         :type local: Optional[bool], optional
         :param default_headers: Set additional HTTP headers to be sent with requests to OpenAI
@@ -181,8 +190,10 @@ class BaseLlmConfig(BaseConfig):
         self.base_url = base_url
         self.endpoint = endpoint
         self.model_kwargs = model_kwargs
-        self.http_client = http_client
-        self.http_async_client = http_async_client
+        self.http_client = httpx.Client(proxies=http_client_proxies) if http_client_proxies else None
+        self.http_async_client = (
+            httpx.AsyncClient(proxies=http_async_client_proxies) if http_async_client_proxies else None
+        )
         self.local = local
         self.default_headers = default_headers
         self.online = online

--- a/embedchain/llm/openai.py
+++ b/embedchain/llm/openai.py
@@ -56,7 +56,13 @@ class OpenAILlm(BaseLlm):
                 http_async_client=config.http_async_client,
             )
         else:
-            chat = ChatOpenAI(**kwargs, api_key=api_key, base_url=base_url)
+            chat = ChatOpenAI(
+                **kwargs,
+                api_key=api_key,
+                base_url=base_url,
+                http_client=config.http_client,
+                http_async_client=config.http_async_client,
+            )
         if self.tools:
             return self._query_function_call(chat, self.tools, messages)
 
@@ -69,8 +75,7 @@ class OpenAILlm(BaseLlm):
         messages: list[BaseMessage],
     ) -> str:
         from langchain.output_parsers.openai_tools import JsonOutputToolsParser
-        from langchain_core.utils.function_calling import \
-            convert_to_openai_tool
+        from langchain_core.utils.function_calling import convert_to_openai_tool
 
         openai_tools = [convert_to_openai_tool(tools)]
         chat = chat.bind(tools=openai_tools).pipe(JsonOutputToolsParser())

--- a/embedchain/utils/misc.py
+++ b/embedchain/utils/misc.py
@@ -442,6 +442,8 @@ def validate_config(config_data):
                     Optional("base_url"): str,
                     Optional("default_headers"): dict,
                     Optional("api_version"): Or(str, datetime.date),
+                    Optional("http_client_proxies"): Or(str, dict),
+                    Optional("http_async_client_proxies"): Or(str, dict),
                 },
             },
             Optional("vectordb"): {


### PR DESCRIPTION
## Description

This would allow users to use pass proxy servers via config. It would allow them to use Embedchain behind a company's proxy setting.

Current implementation lacks creating of `httpx` or any `HttpClient` interface. It expects user a client in config, but there is no documentation on how to use it. I also believe its not possible to pass it this `http_client` value from the config.

This PR allows http proxies to be passed down from config instead, including async proxies (all 
 examples in unit tests). It creates a `httpx.Client` or `httpx.AsyncClient` as mentioned in the [Langchain docs](https://python.langchain.com/v0.2/docs/integrations/llms/openai/) on behalf of the user.

Fixes #1452

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] Documentation update

## How Has This Been Tested?

I tested this on my AzureOpenAI instance, but could not test it for Openai. 

I have unit tests for both, other pr adds azure.

- [x] Unit Test
- [x] Test Script (please provide)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings

## Maintainer Checklist

- [ ] closes #xxxx (Replace xxxx with the GitHub issue number)
- [ ] Made sure Checks passed
